### PR TITLE
use node.set to resolve Chef 11 immutable attributes

### DIFF
--- a/opsworks_custom_cookbooks/recipes/checkout.rb
+++ b/opsworks_custom_cookbooks/recipes/checkout.rb
@@ -4,7 +4,7 @@ prepare_git_checkouts(:user => node[:opsworks_custom_cookbooks][:user],
                       :group => node[:opsworks_custom_cookbooks][:group],
                       :home => node[:opsworks_custom_cookbooks][:home],
                       :ssh_key => node[:opsworks_custom_cookbooks][:scm][:ssh_key]) if node[:opsworks_custom_cookbooks][:scm][:type].to_s == 'git'
-                      
+
 prepare_svn_checkouts(:user => node[:opsworks_custom_cookbooks][:user],
                       :group => node[:opsworks_custom_cookbooks][:group],
                       :home => node[:opsworks_custom_cookbooks][:home],
@@ -12,13 +12,13 @@ prepare_svn_checkouts(:user => node[:opsworks_custom_cookbooks][:user],
 
 if node[:opsworks_custom_cookbooks][:scm][:type].to_s == 'archive'
   repository = prepare_archive_checkouts(node[:opsworks_custom_cookbooks][:scm])
-  node[:opsworks_custom_cookbooks][:scm] = {
+  node.set[:opsworks_custom_cookbooks][:scm] = {
     :type => 'git',
     :repository => repository
   }
 elsif node[:opsworks_custom_cookbooks][:scm][:type].to_s == 's3'
   repository = prepare_s3_checkouts(node[:opsworks_custom_cookbooks][:scm])
-  node[:opsworks_custom_cookbooks][:scm] = {
+  node.set[:opsworks_custom_cookbooks][:scm] = {
    :scm_type => 'git',
    :repository => repository
   }
@@ -27,7 +27,7 @@ end
 scm "Download Custom Cookbooks" do
   user node[:opsworks_custom_cookbooks][:user]
   group node[:opsworks_custom_cookbooks][:group]
-  
+
   case node[:opsworks_custom_cookbooks][:scm][:type]
   when 'git'
     provider Chef::Provider::Git
@@ -40,13 +40,13 @@ scm "Download Custom Cookbooks" do
   else
     raise "unsupported SCM type #{node[:opsworks_custom_cookbooks][:scm][:type].inspect}"
   end
-  
+
   action :checkout
   destination node[:opsworks_custom_cookbooks][:destination]
   repository node[:opsworks_custom_cookbooks][:scm][:repository]
   revision node[:opsworks_custom_cookbooks][:scm][:revision]
   user node[:opsworks_custom_cookbooks][:user]
-  
+
   not_if do
     node[:opsworks_custom_cookbooks][:scm][:repository].blank? || ::File.directory?(node[:opsworks_custom_cookbooks][:destination])
   end


### PR DESCRIPTION
While OpsWorks uses Chef 0.9, users may wish to reuse the cookbooks with newer versions of Chef. In Chef 11, node attributes are immutable, and assignment requires using a priority setting method. I used `Chef::Node#set` here as it is the same thing as Chef 0.9's behavior.
