### PR TITLE
Metadata dependencies

### DIFF
--- a/build-essential/CHANGELOG.md
+++ b/build-essential/CHANGELOG.md
@@ -1,0 +1,11 @@
+## v1.1.0:
+
+* [COOK-1098] - support amazon linux
+* [COOK-1149] - support Mac OS X
+* [COOK-1296] - allow for compile-time installation of packages
+  through an attribute (see README)
+
+## v1.0.2:
+
+* [COOK-1098] - Add Amazon Linux platform support
+* [COOK-1149] - Add OS X platform support

--- a/build-essential/CONTRIBUTING
+++ b/build-essential/CONTRIBUTING
@@ -1,0 +1,29 @@
+If you would like to contribute, please open a ticket in JIRA:
+
+* http://tickets.opscode.com
+
+Create the ticket in the COOK project and use the cookbook name as the
+component.
+
+For all code contributions, we ask that contributors sign a
+contributor license agreement (CLA). Instructions may be found here:
+
+* http://wiki.opscode.com/display/chef/How+to+Contribute
+
+When contributing changes to individual cookbooks, please do not
+modify the version number in the metadata.rb. Also please do not
+update the CHANGELOG.md for a new version. Not all changes to a
+cookbook may be merged and released in the same versions. Opscode will
+handle the version updates during the release process. You are welcome
+to correct typos or otherwise make updates to documentation in the
+README.
+
+If a contribution adds new platforms or platform versions, indicate
+such in the body of the commit message(s), and update the relevant
+COOK ticket. When writing commit messages, it is helpful for others if
+you indicate the COOK ticket. For example:
+
+    git commit -m '[COOK-1041] Updated pool resource to correctly delete.'
+
+In the ticket itself, it is also helpful if you include log output of
+a successful Chef run, but this is not absolutely required.

--- a/build-essential/LICENSE
+++ b/build-essential/LICENSE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/build-essential/README.md
+++ b/build-essential/README.md
@@ -1,0 +1,124 @@
+Description
+===========
+
+Installs packages required for compiling C software from source. Use
+this cookbook if you wish to compile C programs, or install RubyGems
+with native extensions.
+
+Requirements
+============
+
+## Platform
+
+Supported platforms by platform family:
+
+* Linux (debian, rhel, fedora)
+* Darwin (`mac_os_x` 10.6+)
+
+Attributes
+==========
+
+* `node['build_essential']['compiletime']` - Whether the resources in
+the default recipe should be configured at the "Compile" phase of the
+Chef run. Defaults to false, see __Usage__ for more information.
+* `node['build_essential']['osx']['gcc_installer_url']` - The URL of
+  the OS X GCC package installer (.pkg).
+* `node['build_essential']['osx']['gcc_installer_checksum']` - The
+  SHA256 checksum of the OS X GCC installer.
+
+Recipes
+=======
+
+This cookbook has one recipe, default.
+
+On Linux platforms (see __Platform__ above for a supported list of
+families), packages required to build C source projects are installed.
+This includes GCC, make, autconf and others. On Debian-family
+distributions, the apt-cache may need to be updated, especially during
+compile time installation. See __Usage__ for further information.
+
+On Mac OS X, the GCC standalone installer by Kenneth Reitz is
+installed. Note that this is *not* the Xcode CLI package, as that does
+not include all programs and headers required to build some common
+GNU-style C projects, such as those that are available from projects
+such as MacPorts or Homebrew. Changing the attributes for the GCC
+installer URL and checksum to the Xcode values may work, but this is
+untested.
+
+Usage
+=====
+
+Simply include the `build-essential` and the required tools will be
+installed to the system, and later recipes will be able to compile
+software from C source code.
+
+For RubyGems that include native C extensions you wish to use with
+Chef, you should do two things.
+
+0. Ensure that the C libraries, include files and other assorted "dev"
+type packages are installed. You should do this in the compile phase
+after the build-essential recipe.
+1. Use the `chef_gem` resource in your recipes. This requires Chef version 0.10.10+.
+2. Set the `compiletime` attribute in roles where such recipes are
+required. This will ensure that the build tools are available to
+compile the RubyGems' extensions, as `chef_gem` happens during the
+compile phase, too.
+
+Example installation of a devel package at compile-time in a recipe:
+
+    package "mypackage-dev" do
+      action :nothing
+    end.run_action(:install)
+
+Example use of `chef_gem`:
+
+    chef_gem "mygem"
+
+Example role:
+
+    name "myapp"
+    run_list(
+      "recipe[build-essential]",
+      "recipe[myapp]"
+    )
+    default_attributes(
+      "build-essential" => {
+        "compiletime" => true
+      }
+    )
+
+The compile time option (via the attribute) is to ensure that the
+proper packages are available at the right time in the Chef run. It is
+recommended that the build-essential recipe appear early in the run
+list.
+
+The Chef wiki has documentation on
+[the anatomy of a chef run](http://wiki.opscode.com/display/chef/Anatomy+of+a+Chef+Run).
+
+Limitations
+===========
+
+It is not in the scope of this cookbook to handle installing the
+required headers for individual software projects in order to compile
+them, or to compile RubyGems with native C extensions. You should
+create a cookbook for handling that.
+
+License and Author
+==================
+
+Author:: Joshua Timberman (<joshua@opscode.com>)
+Author:: Seth Chisamore (<schisamo@opscode.com>)
+
+Copyright 2009-2011, Opscode, Inc. (<legal@opscode.com>)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/build-essential/attributes/default.rb
+++ b/build-essential/attributes/default.rb
@@ -1,0 +1,32 @@
+#
+# Cookbook Name:: build-essential
+# Attributes:: default
+#
+# Copyright 2008-2012, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default['build_essential']['compiletime'] = false
+
+case platform
+when "mac_os_x"
+  case
+  when Chef::VersionConstraint.new("~> 10.7.0").include?(platform_version)
+    default['build_essential']['osx']['gcc_installer_url'] = "https://github.com/downloads/kennethreitz/osx-gcc-installer/GCC-10.7-v2.pkg"
+    default['build_essential']['osx']['gcc_installer_checksum'] = "df36aa87606feb99d0db9ac9a492819e"
+  when Chef::VersionConstraint.new("~> 10.6.0").include?(platform_version)
+    default['build_essential']['osx']['gcc_installer_url'] = "https://github.com/downloads/kennethreitz/osx-gcc-installer/GCC-10.6.pkg"
+    default['build_essential']['osx']['gcc_installer_checksum'] = "d1db5bab6a3f6b9f3b5577a130baeefa"
+  end
+end

--- a/build-essential/metadata.json
+++ b/build-essential/metadata.json
@@ -1,0 +1,37 @@
+{
+  "name": "build-essential",
+  "description": "Installs C compiler / build tools",
+  "long_description": "",
+  "maintainer": "Opscode, Inc.",
+  "maintainer_email": "cookbooks@opscode.com",
+  "license": "Apache 2.0",
+  "platforms": {
+    "fedora": ">= 0.0.0",
+    "redhat": ">= 0.0.0",
+    "centos": ">= 0.0.0",
+    "ubuntu": ">= 0.0.0",
+    "debian": ">= 0.0.0",
+    "amazon": ">= 0.0.0",
+    "mac_os_x": ">= 10.6.0"
+  },
+  "dependencies": {
+  },
+  "recommendations": {
+  },
+  "suggestions": {
+  },
+  "conflicting": {
+  },
+  "providing": {
+  },
+  "replacing": {
+  },
+  "attributes": {
+  },
+  "groupings": {
+  },
+  "recipes": {
+    "build-essential": "Installs packages required for compiling C software from source."
+  },
+  "version": "1.1.0"
+}

--- a/build-essential/metadata.rb
+++ b/build-essential/metadata.rb
@@ -1,0 +1,12 @@
+maintainer        "Opscode, Inc."
+maintainer_email  "cookbooks@opscode.com"
+license           "Apache 2.0"
+description       "Installs C compiler / build tools"
+version           "1.1.0"
+recipe            "build-essential", "Installs packages required for compiling C software from source."
+
+%w{ fedora redhat centos ubuntu debian amazon }.each do |os|
+  supports os
+end
+
+supports "mac_os_x", ">= 10.6.0"

--- a/build-essential/recipes/default.rb
+++ b/build-essential/recipes/default.rb
@@ -1,0 +1,79 @@
+#
+# Cookbook Name:: build-essential
+# Recipe:: default
+#
+# Copyright 2008-2009, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/shell_out'
+
+compiletime = node['build_essential']['compiletime']
+
+case node['os']
+when "linux"
+
+  # on apt-based platforms when first provisioning we need to force
+  # apt-get update at compiletime if we are going to try to install at compiletime
+  if node['platform_family'] == "debian"
+    execute "apt-get update" do
+      action :nothing
+      # tip: to suppress this running every time, just use the apt cookbook
+      not_if do
+        ::File.exists?('/var/lib/apt/periodic/update-success-stamp') &&
+        ::File.mtime('/var/lib/apt/periodic/update-success-stamp') > Time.now - 86400*2
+      end
+    end.run_action(:run) if compiletime
+  end
+
+  packages = case node['platform_family']
+    when "debian"
+      %w{build-essential binutils-doc}
+    when "rhel", "fedora"
+      %w{gcc gcc-c++ kernel-devel make}
+    end
+
+  packages.each do |pkg|
+    r = package pkg do
+      action ( compiletime ? :nothing : :install )
+    end
+    r.run_action(:install) if compiletime
+  end
+
+  %w{autoconf flex bison}.each do |pkg|
+    r = package pkg do
+      action ( compiletime ? :nothing : :install )
+    end
+    r.run_action(:install) if compiletime
+  end
+when "darwin"
+  result = Chef::ShellOut.new("pkgutil --pkgs").run_command
+  installed = result.stdout.split("\n").include?("com.apple.pkg.gcc4.2Leo")
+  pkg_filename = File.basename(node['build_essential']['osx']['gcc_installer_url'])
+  pkg_path = "#{Chef::Config[:file_cache_path]}/#{pkg_filename}"
+
+  r = remote_file pkg_path do
+    source node['build_essential']['osx']['gcc_installer_url']
+    checksum node['build_essential']['osx']['gcc_installer_checksum']
+    action ( compiletime ? :nothing : :create )
+    not_if { installed }
+  end
+  r.run_action(:create) if compiletime
+
+  r = execute "sudo installer -pkg \"#{pkg_path}\" -target /" do
+    action ( compiletime ? :nothing : :run )
+    not_if { installed }
+  end
+  r.run_action(:run) if compiletime
+end

--- a/dependencies/metadata.rb
+++ b/dependencies/metadata.rb
@@ -1,35 +1,34 @@
 maintainer "Amazon Web Services"
 description "Install .gem and .deb depencencies"
 version "0.1"
+depends "packages"
+depends "gem_support"
+depends "ruby_enterprise"
+depends "ruby"
+
 recipe "dependencies::update", "Update all packages and gems"
 
 attribute "dependencies/gems",
   :display_name => "Gems to install",
   :description => "A list of Rubygems to install",
-  :required => false,
-  :type => 'hash'
+  :required => false
 
 attribute "dependencies/debs",
   :display_name => "Debian packages to install",
   :description => "A list of Debian packages (.deb) to install",
-  :required => false,
-  :type => 'hash'
-  
+  :required => false
+
 attribute "dependencies/update_debs",
   :display_name => "Update sources",
   :description => "Update sources using apt-get update",
-  :required => false,
-  :type => 'boolean'
+  :required => false
 
 attribute "dependencies/upgrade_debs",
   :display_name => "Update packages",
   :description => "Update packages using apt-get upgrade",
-  :required => false,
-  :type => 'boolean'
+  :required => false
 
 attribute "dependencies/upgrade_gems",
   :display_name => "Update gems",
   :description => "Update gems using gem update",
-  :required => false,
-  :type => 'boolean'
-
+  :required => false

--- a/deploy/metadata.rb
+++ b/deploy/metadata.rb
@@ -1,6 +1,13 @@
 maintainer "Amazon Web Services"
 description "Deploy applications"
 version "0.1"
+depends "scm_helper"
+depends "dependencies"
+depends "apache2"
+depends "mod_php5_apache2"
+depends "deploy"
+depends "nginx"
+
 recipe "deploy::scm", "Install and setup the source code management system"
 recipe "deploy::rails", "Deploy a Rails application"
 recipe "deploy::php", "Deploy a PHP application"

--- a/mod_php5_apache2/metadata.rb
+++ b/mod_php5_apache2/metadata.rb
@@ -4,3 +4,4 @@ description      "Installs/Configures Apache with mod_php5"
 version          "0.1"
 
 supports "ubuntu"
+depends "apache2"

--- a/opsworks_custom_cookbooks/metadata.rb
+++ b/opsworks_custom_cookbooks/metadata.rb
@@ -2,6 +2,9 @@ maintainer "Amazon Web Services"
 description "Supports custom user cookbooks"
 version "0.1"
 
+depends "opsworks_initial_setup"
+depends "scm_helper"
+
 recipe "opsworks_custom_cookbooks::checkout", "Checkout custom Cookbooks"
 recipe "opsworks_custom_cookbooks::load", "Load custom Cookbooks"
 recipe "opsworks_custom_cookbooks::execute", "Execute custom Cookbooks"
@@ -10,5 +13,4 @@ recipe "opsworks_custom_cookbooks::update", "Update custom Cookbooks"
 attribute "opsworks_custom_cookbooks/repository",
   :display_name => "URL to you Chef cookbooks",
   :description => "URL to you Chef cookbooks",
-  :required => true,
-  :type => 'string'
+  :required => true

--- a/opsworks_ganglia/metadata.rb
+++ b/opsworks_ganglia/metadata.rb
@@ -1,7 +1,8 @@
 maintainer "Amazon Web Services"
 version "0.2"
 supports "ubuntu"
-
+depends "opsworks_commons"
+depends "apache2"
 recipe "opsworks_ganglia::server", "Ganglia server"
 recipe "opsworks_ganglia::configure-server", "Reconfigure Ganglia server with correct clients"
 recipe "opsworks_ganglia::client", "Ganglia client"

--- a/passenger_apache2/metadata.rb
+++ b/passenger_apache2/metadata.rb
@@ -5,7 +5,7 @@ description       "Installs passenger for Apache2"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
 version           "0.11"
 
-%w{ packages apache2 rails }.each do |cb|
+%w{ packages apache2 rails gem_support nginx unicorn }.each do |cb|
   depends cb
 end
 

--- a/rails/metadata.rb
+++ b/rails/metadata.rb
@@ -5,6 +5,7 @@ supports "ubuntu", ">= 8.10"
 
 recipe "rails::configure", "Re-configure a Rails application"
 
+depends "deploy"
 depends "apache2"
 depends "nginx"
 

--- a/ruby_enterprise/metadata.rb
+++ b/ruby_enterprise/metadata.rb
@@ -4,4 +4,6 @@ description      "Installs/Configures ruby-enterprise"
 version          "0.1"
 
 depends "build-essential"
+depends "opsworks_rubygems"
+depends "opsworks_bundler"
 supports "ubuntu"

--- a/ssh_users/metadata.rb
+++ b/ssh_users/metadata.rb
@@ -1,3 +1,4 @@
 maintainer 'Amazon Web Services'
 description 'Create system users for OpsWorks users with personal SSH keys'
 version '0.1'
+depends "opsworks_initial_setup"


### PR DESCRIPTION
While OpsWorks uses Chef Solo, the cookbooks don't declare proper dependencies where required. This is okay under solo because all the cookbooks must be sent to the node (which OpsWorks handles). However, if one were to use these cookbooks with a Chef Server, the client would not have the right cookbooks available.

Also, the build-essential is listed as a dependency of ruby_enterprise, but it is not in the repository. I added a version of the build-essential cookbook that works in my testing.
