### PR TITLE
Fixed unable to restart service when trying to invoke recipe in custom layer

### DIFF
--- a/apache2/recipes/mod_php5.rb
+++ b/apache2/recipes/mod_php5.rb
@@ -37,7 +37,7 @@ when 'centos', 'redhat', 'fedora', 'amazon'
   # replace with debian config
   template File.join(node[:apache][:dir], 'mods-available', 'php5.conf') do
     source 'mods/php5.conf.erb'
-    notifies :restart, 'service[apache2]'
+    notifies :restart, resources(:service => 'apache2')
   end
 end
 


### PR DESCRIPTION
I was receiving this error when trying to invoke this recipe from a custom layer:

DEBUG: Re-raising exception: NoMethodError - undefined method
`run_action' for "service[apache2]":String

Referencing the service in this way seems to correct the problem. 
