### PR TITLE
Allow nginx to access to the unicorn socket

### DIFF
--- a/deploy/definitions/opsworks_deploy_dir.rb
+++ b/deploy/definitions/opsworks_deploy_dir.rb
@@ -1,7 +1,7 @@
 define :opsworks_deploy_dir do
 
   # create shared/ directory structure
-  ['log','config','system','pids','scripts','sockets'].each do |dir_name|
+  ['log','config','system','pids','scripts'].each do |dir_name|
     directory "#{params[:path]}/shared/#{dir_name}" do
       group params[:group]
       owner params[:user]
@@ -9,6 +9,14 @@ define :opsworks_deploy_dir do
       action :create
       recursive true
     end
+  end
+  
+  directory "#{params[:path]}/shared/sockets" do
+    group params[:group]
+    owner params[:user]
+    mode 0777
+    action :create
+    recursive true
   end
 
 end


### PR DESCRIPTION
I have exactly the issue described here:

https://forums.aws.amazon.com/thread.jspa?threadID=118236

Nginx can't write to the unicorn socket because of the shared/sockets directory's permissions.

Example error message:

_...connect() to unix:/srv/www/myapp/shared/sockets/unicorn.sock failed (13: Permission denied) while connecting to upstream, client: 10.158.40.157, server: myapp.com, request: "OPTIONS / HTTP/1.0", upstream: "http://unix:/srv/www/myapp/shared/sockets/unicorn.sock:/"_

This proposed change expands the permissions on the sockets directory. Thanks for considering it!
