### PR TITLE
Fix minor syntax errors in cookbook specs

### DIFF
--- a/deploy/specs/php-undeploy_spec.rb
+++ b/deploy/specs/php-undeploy_spec.rb
@@ -18,7 +18,7 @@ describe_recipe 'deploy::php-undeploy' do
 
   it 'deletes the application directory' do
     if deploy[:application_type] = 'php'
-      directory("#{deploy[:deploy_to]}".wont_exist
+      directory("#{deploy[:deploy_to]}").wont_exist
     end
   end
 end

--- a/deploy/specs/php_spec.rb
+++ b/deploy/specs/php_spec.rb
@@ -4,29 +4,30 @@ describe_recipe 'deploy::php' do
   include MiniTest::Chef::Resources
   include MiniTest::Chef::Assertions
 
-node['deploy'].each do |application, deploy|
-  if deploy[:application_type] = 'php'
+  node['deploy'].each do |application, deploy|
+    if deploy[:application_type] = 'php'
 
-    it 'creates a deployment directory' do
-      directory(node[:deploy][app][:deploy_to]).must_exist(:mode, '0775').with(:owner, deploy[:user]).and(:group, deploy[:group])
-    end
-
-    ['log','config','system','pids','scripts','sockets'].each do |dir_name|
-      it "creates a directory #{dir_name} in the deployment directory" do
-        directory(node[:deploy][app][:deploy_to]} + '/' + dir_name).must_exist(:mode, '0770').with(:owner, deploy[:user]).and(:group, deploy[:group])
+      it 'creates a deployment directory' do
+        directory(node[:deploy][app][:deploy_to]).must_exist(:mode, '0775').with(:owner, deploy[:user]).and(:group, deploy[:group])
       end
-    end
 
-    it 'creates the apache site-available link' do
-      file("#{node[:apache][:dir]}/sites-available/#{application}.conf").must_exist
-    end
+      ['log','config','system','pids','scripts','sockets'].each do |dir_name|
+        it "creates a directory #{dir_name} in the deployment directory" do
+          directory(node[:deploy][app][:deploy_to] + '/' + dir_name).must_exist(:mode, '0770').with(:owner, deploy[:user]).and(:group, deploy[:group])
+        end
+      end
 
-    it 'creates the apache site-enebled link' do
-      file("#{node[:apache][:dir]}/sites-enabled/#{application}.conf").must_exist
-    end
+      it 'creates the apache site-available link' do
+        file("#{node[:apache][:dir]}/sites-available/#{application}.conf").must_exist
+      end
 
-    it 'creates a logrotate configuration' do
-      file("/etc/logrotate.d/opsworks_app_#{application}").must_exist(:mode, '0644').with(:owner, 'root').and(:group, 'root')
+      it 'creates the apache site-enebled link' do
+        file("#{node[:apache][:dir]}/sites-enabled/#{application}.conf").must_exist
+      end
+
+      it 'creates a logrotate configuration' do
+        file("/etc/logrotate.d/opsworks_app_#{application}").must_exist(:mode, '0644').with(:owner, 'root').and(:group, 'root')
+      end
     end
   end
 end

--- a/opsworks_initial_setup/specs/hosts_spec.rb
+++ b/opsworks_initial_setup/specs/hosts_spec.rb
@@ -5,17 +5,16 @@ describe_recipe 'opsworks_initial_setup::hosts' do
   include MiniTest::Chef::Assertions
 
   it 'creates entries for all hosts on the same stack which are online ' do
-     node[:opsworks][:layers].each do |layer_name, layer_config| -%>
-       layer_config[:instances].each do |instance_name, instance_config|
-         if !seen.include?(instance_name) && instance_config[:private_ip]
-           file('/etc/hosts').must_include "#{Resolv.getaddress(instance_config[:private_ip])} #{instance_name}"
-           if instance_config[:ip]
-             file('/etc/hosts').must_include "#{Resolv.getaddress(instance_config[:ip])} #{instance_name}-ext"
-           end
-           seen << instance_name
-         end
-       end
-     end
+    node[:opsworks][:layers].each do |layer_name, layer_config|
+      layer_config[:instances].each do |instance_name, instance_config|
+        if !seen.include?(instance_name) && instance_config[:private_ip]
+          file('/etc/hosts').must_include "#{Resolv.getaddress(instance_config[:private_ip])} #{instance_name}"
+          if instance_config[:ip]
+            file('/etc/hosts').must_include "#{Resolv.getaddress(instance_config[:ip])} #{instance_name}-ext"
+          end
+          seen << instance_name
+        end
+      end
     end
   end
 end

--- a/opsworks_nodejs/specs/configure_spec.rb
+++ b/opsworks_nodejs/specs/configure_spec.rb
@@ -8,7 +8,7 @@ describe_recipe 'opsworks_nodejs::configure' do
     config = File.join("#{deploy[:deploy_to]}",'shared/config/opsworks.js')
     file( config ).must_exist.with(
          :mode, '0660').and(:owner, "#{deploy[:user]}").and(:group, "#{deploy[:group]}")
-    file( config ).must_match/^exports.db\ =\ #{deploy[:database].to_json}/
-    file( config ).must_match/^exports.memcached\ =\ #{deploy[:memcached].to_json}/
+    file( config ).must_match(/^exports.db\ =\ #{deploy[:database].to_json}/)
+    file( config ).must_match(/^exports.memcached\ =\ #{deploy[:memcached].to_json}/)
   end
 end


### PR DESCRIPTION
`rake validate_syntax` fails due to a number of small ruby syntax errors
in the cookbooks:
- `opsworks_nodejs` needed a space or method brackets around a couple of
  regex arguments.
- `opsworks_initial_setup/specs/hosts_spec.rb` contained a rogue closing
  tag and an extra `end` statement.
- Specs for php deploy were a bit bung. Haven't run them so don't know
  if they pass, but at least they are valid ruby now.
