### PR TITLE
Update mysql to use `utf8_unicode_ci` collation by default

### DIFF
--- a/mysql/templates/default/my.cnf.erb
+++ b/mysql/templates/default/my.cnf.erb
@@ -6,6 +6,7 @@
 [client]
 port                  = <%= node[:mysql][:port] %>
 socket                = <%= node[:mysql][:socket] %>
+default-character-set = utf8
 
 [mysqld_safe]
 socket          = <%= node[:mysql][:socket] %>
@@ -20,7 +21,10 @@ basedir         = <%= node[:mysql][:basedir] %>
 datadir         = <%= node[:mysql][:datadir] %>
 tmpdir          = /tmp
 
-character-set-server		= utf8
+character-set-server    = utf8
+collation-server        = utf8_unicode_ci
+init_connect            = 'SET collation_connection = utf8_unicode_ci'
+init_connect            = 'SET NAMES utf8'
 
 default-storage-engine=innodb
 skip-external-locking

--- a/mysql/templates/ubuntu-12.04/my.cnf.erb
+++ b/mysql/templates/ubuntu-12.04/my.cnf.erb
@@ -25,7 +25,10 @@ basedir         = <%= node[:mysql][:basedir] %>
 datadir         = <%= node[:mysql][:datadir] %>
 tmpdir          = /tmp
 
-character-set-server		= utf8
+character-set-server    = utf8
+collation-server        = utf8_unicode_ci
+init_connect            = 'SET collation_connection = utf8_unicode_ci'
+init_connect            = 'SET NAMES utf8'
 
 default-storage-engine=innodb
 skip-external-locking


### PR DESCRIPTION
MySQL's default collation for utf8 is `utf8_general_ci`, which is
apparently more performant but less correct than `utf8_unicode_ci`. A
default install should be more correct than fast, so this change
explicitely sets the collation to be `utf8_unicode_ci`.

One can check the default character set and collation by issuing the
following query on the client:

```
show variables like "%character%";show variables like "%collation%";
```
## Further Reading
- [Server Character Set and Collation](https://dev.mysql.com/doc/refman/5.5/en/charset-server.html)
- [StackOverflow discussion](http://stackoverflow.com/questions/3513773/change-mysql-default-character-set-to-utf8-in-my-cnf)
