### PR TITLE
[Bugfix] [Rails] [Patch attached] Escape all of the attributes that need escaped in database.yml

### DIFF
--- a/rails/templates/default/database.yml.erb
+++ b/rails/templates/default/database.yml.erb
@@ -1,11 +1,11 @@
 <% (['development', 'production'] + [@environment]).uniq.each do |env| -%>
 <%= env %>:
-  adapter: <%= @database[:adapter] %>
-  database: <%= @database[:database] %>
+  adapter: <%= @database[:adapter].to_s.inspect %>
+  database: <%= @database[:database].to_s.inspect %>
   encoding: utf8
-  host: <%= @database[:host] || 'localhost' %>
-  username: <%= @database[:username] %>
-  password: <%= @database[:password] %>
+  host: <%= @database[:host].to_s.inspect || 'localhost' %>
+  username: <%= @database[:username].to_s.inspect %>
+  password: <%= @database[:password].to_s.inspect %>
   reconnect: <%= @database[:reconnect] ? 'true' : 'false' %>
 
 <% end -%>


### PR DESCRIPTION
This allows you to use passwords with special characters, for example.
