### PR TITLE
[Feature] [Rails] [Unicorn] [Nginx] Allow the application to set its client_max_body_size.

### DIFF
--- a/unicorn/templates/default/nginx_unicorn_web_app.erb
+++ b/unicorn/templates/default/nginx_unicorn_web_app.erb
@@ -11,6 +11,10 @@ server {
 
   root <%= @application[:absolute_document_root] %>;
 
+  <% if @application[:nginx] && @application[:nginx][:client_max_body_size] %>
+    client_max_body_size <%= @application[:nginx][:client_max_body_size] %>;
+  <% end %>
+
   location / {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
@@ -53,6 +57,10 @@ server {
   keepalive_timeout 5;
 
   root <%= @application[:absolute_document_root] %>;
+
+  <% if @application[:nginx] && @application[:nginx][:client_max_body_size] %>
+    client_max_body_size <%= @application[:nginx][:client_max_body_size] %>;
+  <% end %>
 
   location / {
     proxy_set_header X-Forwarded-Proto https;


### PR DESCRIPTION
Our applications typically need to be able to accept request bodies larger than the Nginx default, so this needs to be configurable. This patch makes this possible (at least for Unicorn+Nginx; similar change needs to happen if you ever support Passenger+Nginx).

Note that a `client_max_body_size` can be specified at the server level, but if you were to host multiple apps per server, you might not want a global default.
