### PR TITLE
Multiple custom cookbook paths

### DIFF
--- a/opsworks_custom_cookbooks/attributes/default.rb
+++ b/opsworks_custom_cookbooks/attributes/default.rb
@@ -6,6 +6,7 @@ default[:opsworks_custom_cookbooks][:group] = 'root'
 default[:opsworks_custom_cookbooks][:home] = '/root'
 default[:opsworks_custom_cookbooks][:destination] = "#{node[:opsworks_agent][:current_dir]}/site-cookbooks"
 
+default[:opsworks_custom_cookbooks][:cookbooks_paths] = []
 default[:opsworks_custom_cookbooks][:recipes] = []
 
 default[:opsworks_custom_cookbooks][:scm] = {}

--- a/opsworks_custom_cookbooks/metadata.rb
+++ b/opsworks_custom_cookbooks/metadata.rb
@@ -12,3 +12,9 @@ attribute "opsworks_custom_cookbooks/repository",
   :description => "URL to you Chef cookbooks",
   :required => true,
   :type => 'string'
+
+attribute "opsworks_custom_cookbooks/cookbooks_paths",
+  :display_name => "Additional Cookbook Paths",
+  :description => "Additional paths to search for cookbooks, relative to your repository root",
+  :type => "array",
+  :default => []

--- a/opsworks_custom_cookbooks/recipes/default.rb
+++ b/opsworks_custom_cookbooks/recipes/default.rb
@@ -8,7 +8,10 @@ ruby_block "load and execute the new cookbooks" do
       Chef::Log.info("Loading custom cookbooks from #{node[:opsworks_custom_cookbooks][:destination]}")
       
       # add new Cookbooks and keep old
-      Chef::Config.cookbook_path = [Chef::Config.cookbook_path, node[:opsworks_custom_cookbooks][:destination]].flatten
+      additional_cookbooks = Array(node[:opsworks_custom_cookbooks][:cookbooks_path]).map do |path|
+        ::Pathname.join(node[:opsworks_custom_cookbooks][:destination], path)
+      end
+      Chef::Config.cookbook_path = [Chef::Config.cookbook_path, node[:opsworks_custom_cookbooks][:destination], additional_cookbooks].flatten
       
       load_new_cookbooks
 


### PR DESCRIPTION
I'm trying to configure my application using OpsWorks. My cookbooks are contained within my main code repository, in a sub-folder. I also organize my cookbooks into a couple of different directories.

Trying to figure out how to configure this correctly in OpsWorks, I found [this line](https://github.com/aws/opsworks-cookbooks/blob/master/opsworks_custom_cookbooks/recipes/default.rb#L11), which seems to add the `node[:opsworks_custom_cookbooks][:destination]` attribute to the cookbooks path. Trying to take the hint off of the call to Array.flatten, I tried setting the "Custom Chef JSON" form field of my stack to this:

``` json
{
  "opsworks_custom_cookbooks": {
    "destination": [
      "/opt/aws/opsworks/current/path/to/custom/cookbook",
      "/opt/aws/opsworks/current/path/to/another/cookbook"
    ]
  }
}
```

However, setting this attribute to the path of my cookbooks does not work, as the attribute is used in other recipes to initially clone the cookbook repository, as seen here in the [opsworks_custom_cookbooks::checkout recipe](https://github.com/aws/opsworks-cookbooks/blob/master/opsworks_custom_cookbooks/recipes/checkout.rb#L45).

I thought a good solution might be to include another optional attribute to the recipe, which would allow the user to specify an array of custom, relative paths pointing to their cookbook folders within their cookbook repository.

This would allow a user to specify something like this:

``` json
{
  "opsworks_custom_cookbooks": {
    "cookbook_paths": [
      "path/to/custom/cookbook",
      "path/to/another/cookbook"
    ]
  }
}
```
