### PR TITLE
removed invalid boolean types from metadata.rb in dependencies cookbook

### DIFF
--- a/dependencies/metadata.rb
+++ b/dependencies/metadata.rb
@@ -18,18 +18,15 @@ attribute "dependencies/debs",
 attribute "dependencies/update_debs",
   :display_name => "Update sources",
   :description => "Update sources using apt-get update",
-  :required => false,
-  :type => 'boolean'
+  :required => false
 
 attribute "dependencies/upgrade_debs",
   :display_name => "Update packages",
   :description => "Update packages using apt-get upgrade",
-  :required => false,
-  :type => 'boolean'
+  :required => false
 
 attribute "dependencies/upgrade_gems",
   :display_name => "Update gems",
   :description => "Update gems using gem update",
-  :required => false,
-  :type => 'boolean'
+  :required => false
 


### PR DESCRIPTION
Per http://docs.opscode.com/essentials_cookbook_metadata.html, the `type` parameter of an `attribute` defined in `metadata.rb` can only have values `'string'` or `'array'`.  

However, the `type` parameter in the dependencies cookbook is set to `'boolean'`.  Since the `type` parameter is not required, this PR just removes these invalid `type` uses from this cookbook's metadata.

Note that this change is also in #6's larger attempt to fix up metadata.  Also, https://github.com/scalarium/cookbooks/pull/15 tries to fix this same problem with the dependencies cookbook but they go further to say that the `type` should be `'string'` and they also change the use of `true` and `false` in the cookbook to `'true'` and `'false'`.  I imagine the current use of booleans in the cookbook code is working, so I didn't make that change.

Reference: #31 
