### PR TITLE
grep regular expression should not have slashes around it

### DIFF
--- a/scm_helper/libraries/git.rb
+++ b/scm_helper/libraries/git.rb
@@ -21,7 +21,7 @@ module OpsWorks
         end
         
         execute "echo 'StrictHostKeyChecking no' > #{options[:home]}/.ssh/config" do
-          not_if "grep '/^StrictHostKeyChecking no$/' #{options[:home]}/.ssh/config"
+          not_if "grep '^StrictHostKeyChecking no$' #{options[:home]}/.ssh/config"
         end
         
         template "#{options[:home]}/.ssh/id_dsa" do


### PR DESCRIPTION
The slashes in the grep regular expression cause it to always fail and thus always clober .ssh/config
