### PR TITLE
Include SSL information in the headers for Unicorn

### DIFF
--- a/unicorn/templates/default/nginx_unicorn_web_app.erb
+++ b/unicorn/templates/default/nginx_unicorn_web_app.erb
@@ -17,6 +17,11 @@ server {
 
   location / {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-SSL-Cipher "";
+    proxy_set_header X-SSL-Client-Serial "";
+    proxy_set_header X-SSL-Client-S-DN "";
+    proxy_set_header X-SSL-Client-I-DN "";
+    proxy_set_header X-SSL-Protocol "";
     proxy_set_header Host $http_host;
     proxy_redirect off;
 
@@ -65,6 +70,11 @@ server {
   location / {
     proxy_set_header X-Forwarded-Proto https;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-SSL-Cipher $ssl_cipher;
+    proxy_set_header X-SSL-Client-Serial $ssl_client_serial;
+    proxy_set_header X-SSL-Client-S-DN $ssl_client_s_dn;
+    proxy_set_header X-SSL-Client-I-DN $ssl_client_i_dn;
+    proxy_set_header X-SSL-Protocol $ssl_protocol;
     proxy_set_header Host $http_host;
     proxy_redirect off;
 


### PR DESCRIPTION
Unicorn is unable to get detailed SSL information because it is not exposed via the headers. This patch adds this support. There are a couple of SSL variables we aren't sending to the upstream Unicorn because it would be a lot of data (like the entire client SSL certificate ;)). See [NginxHttpSslModule](http://wiki.nginx.org/NginxHttpSslModule) for that list.
