### PR TITLE
[Unicorn] Add the ability to verify SSL client certificates.

### DIFF
--- a/unicorn/templates/default/nginx_unicorn_web_app.erb
+++ b/unicorn/templates/default/nginx_unicorn_web_app.erb
@@ -53,6 +53,9 @@ server {
   <% if @application[:ssl_certificate_ca] -%>
   ssl_client_certificate /etc/nginx/ssl/<%= @application[:domains].first %>.ca;
   <% end -%>
+  <% if @application[:nginx] && @application[:nginx][:ssl_verify_client] -%>
+  ssl_verify_client <%= @application[:nginx][:ssl_verify_client] %>;
+  <% end -%>
 
   keepalive_timeout 5;
 


### PR DESCRIPTION
We needed the ability to tell Nginx to verify SSL client certificates, so we made this cookbook change.
