### PR TITLE
Drop SYN packets during HAProxy reload

### DIFF
--- a/haproxy/recipes/configure.rb
+++ b/haproxy/recipes/configure.rb
@@ -9,7 +9,18 @@ template "/etc/haproxy/haproxy.cfg" do
   owner "root"
   group "root"
   mode 0644
-  notifies :reload, resources(:service => "haproxy")
+  notifies :run, "bash[reload haproxy]"
+end
+
+bash "reload haproxy" do
+  code <<-EOH
+    iptables -I INPUT -p tcp --dport 80 --syn -j DROP
+    iptables -I INPUT -p tcp --dport 443 --syn -j DROP
+    sleep 1
+    service haproxy reload
+    iptables -D INPUT -p tcp --dport 80 --syn -j DROP
+    iptables -D INPUT -p tcp --dport 443 --syn -j DROP
+  EOH
 end
 
 execute "echo 'checking if HAProxy is not running - if so start it'" do


### PR DESCRIPTION
During HAProxy reload TCP connections can be reset, due to a short window when the file descriptors are handed over to the new process. The patch works around most of this problem by dropping SYN packets during reload, which will lead to clients resending the packets until the new process is started.

See discussion here:
http://www.mail-archive.com/haproxy@formilux.org/msg06885.html

We have tested this in production for weeks now, enjoying lower error rates due to less dropped connections.
