### PR TITLE
Typo correction

### DIFF
--- a/nginx/attributes/nginx.rb
+++ b/nginx/attributes/nginx.rb
@@ -12,7 +12,7 @@ when 'centos','redhat','fedora','amazon'
   nginx[:user]    = 'nginx'
   nginx[:binary]  = '/usr/sbin/nginx'
 else
-  Chef::Log.error "Cannot configure nginx, platform unkown"
+  Chef::Log.error "Cannot configure nginx, platform unknown"
 end
 
 # increase if you accept large uploads


### PR DESCRIPTION
Fixed spelling on Error:

"Cannot configure nginx, platform unkown"

to

"Cannot configure nginx, platform unknown"
