### PR TITLE
Change mod_php5 webapp log verbosity to error

### DIFF
--- a/mod_php5_apache2/templates/default/web_app.conf.erb
+++ b/mod_php5_apache2/templates/default/web_app.conf.erb
@@ -22,7 +22,7 @@
     Deny from all
   </Directory>
 
-  LogLevel info
+  LogLevel error
   ErrorLog <%= node[:apache][:log_dir] %>/<%= @params[:name] %>-error.log
   CustomLog <%= node[:apache][:log_dir] %>/<%= @params[:name] %>-access.log combined
   CustomLog <%= node[:apache][:log_dir] %>/<%= @params[:name] %>-ganglia.log ganglia
@@ -75,7 +75,7 @@
     Deny from all
   </Directory>
 
-  LogLevel info
+  LogLevel error
   ErrorLog <%= node[:apache][:log_dir] %>/<%= @params[:name] %>-error.log
   CustomLog <%= node[:apache][:log_dir] %>/<%= @params[:name] %>-ssl-access.log combined
   CustomLog <%= node[:apache][:log_dir] %>/<%= @params[:name] %>-ssl-ganglia.log ganglia


### PR DESCRIPTION
The currently configured LogLevel causes tons of needless log messages like this to be output: 

`Initial (No.1) HTTPS request received for child 25 (server abc.xyz.com:443)`
