### PR TITLE
Added support for multiple backends with health checks

### DIFF
--- a/haproxy/templates/default/haproxy.cfg.erb
+++ b/haproxy/templates/default/haproxy.cfg.erb
@@ -278,4 +278,22 @@ frontend https-in
     <% end -%>
   use_backend static_servers_ssl_<%= app_name %> if static_applications_ssl_<%= app_name %>
   <% end -%>
+  
+  <% if !node[:haproxy][:rails_backends].empty? -%>
+    <% node[:haproxy][:rails_applications].first do |app_name, app_config| -%>
+  default_backend rails_app_servers_ssl_<%= app_name %>
+    <% end -%>
+  <% elsif !node[:haproxy][:php_backends].empty? -%>
+    <% node[:haproxy][:php_applications].first do |app_name, app_config| -%>
+  default_backend php_app_servers_ssl_<%= app_name %>
+    <% end -%>
+  <% elsif !node[:haproxy][:nodejs_backends].empty? -%>
+    <% node[:haproxy][:nodejs_applications].first do |app_name, app_config| -%>
+  default_backend nodejs_app_servers_ssl_<%= app_name %>
+    <% end -%>
+  <% elsif !node[:haproxy][:static_backends].empty? -%>
+    <% node[:haproxy][:static_applications].first do |app_name, app_config| -%>
+  default_backend static_app_servers_ssl_<%= app_name %>
+    <% end -%>
+  <% end -%>
 <% end -%>  

--- a/haproxy/templates/default/haproxy.cfg.erb
+++ b/haproxy/templates/default/haproxy.cfg.erb
@@ -44,19 +44,22 @@ listen application 0.0.0.0:80
   server localhost 127.0.0.1:8080 weight 1 maxconn 5 check
 <% else -%>
 
+<% node[:haproxy][:rails_applications].each do |app_name, app_config| -%>
 <% if !node[:haproxy][:rails_backends].empty? -%>
-backend rails_app_servers
+backend rails_app_servers_<%= app_name %>
   balance <%= node[:haproxy][:balance] %>
   option redispatch
   option forwardfor
-  option httpchk <%= node[:haproxy][:health_check_method] %> <%= node[:haproxy][:health_check_url] %>
+  option httpchk <%= node[:haproxy][:health_check_method] %> <%= node[:haproxy][:health_check_url] %> HTTP/1.0\r\nHost:\ <%= app_config[:domains].first %>
   <% node[:haproxy][:rails_backends].each do |backend| -%>
   server <%= backend['name'] %> <%= backend['ip'] %>:80 weight <%= backend['backends'] || 10 %> maxconn <%= backend['backends'] * node[:haproxy][:maxcon_factor_rails_app] %> check inter <%= node[:haproxy][:check_interval] %>
   <% end -%>
 <% end -%>
+<% end -%>
 
+<% node[:haproxy][:rails_applications].each do |app_name, app_config| -%>
 <% if !node[:haproxy][:rails_backends].empty? -%>
-backend rails_app_servers_ssl
+backend rails_app_servers_ssl_<%= app_name %>
   mode tcp
   balance <%= node[:haproxy][:balance] %>
   option redispatch
@@ -65,20 +68,24 @@ backend rails_app_servers_ssl
   server <%= backend['name'] %> <%= backend['ip'] %>:443 weight <%= backend['backends'] || 10 %> maxconn <%= backend['backends'] * node[:haproxy][:maxcon_factor_rails_app_ssl] %> check inter <%= node[:haproxy][:check_interval] %>
   <% end -%>
 <% end -%>
-  
+<% end -%>
+
+<% node[:haproxy][:php_applications].each do |app_name, app_config| -%>
 <% if !node[:haproxy][:php_backends].empty? -%>  
-backend php_app_servers
+backend php_app_servers_<%= app_name %>
   balance <%= node[:haproxy][:balance] %>
   option redispatch
   option forwardfor
   option httpchk <%= node[:haproxy][:health_check_method] %> <%= node[:haproxy][:health_check_url] %>
   <% node[:haproxy][:php_backends].each do |backend| -%>
-  server <%= backend['name'] %> <%= backend['ip'] %>:80 weight <%= backend['backends'] || 10 %> maxconn <%= backend['backends'] * node[:haproxy][:maxcon_factor_php_app] %> check inter <%= node[:haproxy][:check_interval] %>
+  server <%= backend['name'] %> <%= backend['ip'] %>:80 weight <%= backend['backends'] || 10 %> maxconn <%= backend['backends'] * node[:haproxy][:maxcon_factor_php_app] %> check inter <%= node[:haproxy][:check_interval] %> HTTP/1.0\r\nHost:\ <%= app_config[:domains].first %>
   <% end -%>  
 <% end -%>
+<% end -%>
 
+<% node[:haproxy][:php_applications].each do |app_name, app_config| -%>
 <% if !node[:haproxy][:php_backends].empty? -%>  
-backend php_app_servers_ssl
+backend php_app_servers_ssl_<%= app_name %>
   mode tcp
   balance <%= node[:haproxy][:balance] %>
   option redispatch
@@ -87,20 +94,25 @@ backend php_app_servers_ssl
   server <%= backend['name'] %> <%= backend['ip'] %>:443 weight <%= backend['backends'] || 10 %> maxconn <%= backend['backends'] * node[:haproxy][:maxcon_factor_php_app_ssl] %> check inter <%= node[:haproxy][:check_interval] %>
   <% end -%>  
 <% end -%>
+<% end -%>
 
+<% node[:haproxy][:nodejs_applications].each do |app_name, app_config| -%>
 <% if !node[:haproxy][:nodejs_backends].empty? -%>
-backend nodejs_app_servers
+
+backend nodejs_app_servers_<%= app_name %>
   balance <%= node[:haproxy][:balance] %>
   option redispatch
   option forwardfor
   option httpchk <%= node[:haproxy][:health_check_method] %> <%= node[:haproxy][:health_check_url] %>
   <% node[:haproxy][:nodejs_backends].each do |backend| -%>
-  server <%= backend['name'] %> <%= backend['ip'] %>:80 weight <%= backend['backends'] || 10 %> maxconn <%= backend['backends'] * node[:haproxy][:maxcon_factor_nodejs_app] %> check inter <%= node[:haproxy][:check_interval] %>
+  server <%= backend['name'] %> <%= backend['ip'] %>:80 weight <%= backend['backends'] || 10 %> maxconn <%= backend['backends'] * node[:haproxy][:maxcon_factor_nodejs_app] %> check inter <%= node[:haproxy][:check_interval] %> HTTP/1.0\r\nHost:\ <%= app_config[:domains].first %>
   <% end -%>
 <% end -%>
+<% end -%>
 
+<% node[:haproxy][:nodejs_applications].each do |app_name, app_config| -%>
 <% if !node[:haproxy][:nodejs_backends].empty? -%>
-backend nodejs_app_servers_ssl
+backend nodejs_app_servers_ssl_<%= app_name %>
   mode tcp
   balance <%= node[:haproxy][:balance] %>
   option redispatch
@@ -109,20 +121,24 @@ backend nodejs_app_servers_ssl
   server <%= backend['name'] %> <%= backend['ip'] %>:443 weight <%= backend['backends'] || 10 %> maxconn <%= backend['backends'] * node[:haproxy][:maxcon_factor_nodejs_app_ssl] %> check inter <%= node[:haproxy][:check_interval] %>
   <% end -%>
 <% end -%>
+<% end -%>
 
+<% node[:haproxy][:static_applications].each do |app_name, app_config| -%>
 <% if !node[:haproxy][:static_backends].empty? -%>  
-backend static_servers
+backend static_servers_<%= app_name %>
   balance <%= node[:haproxy][:balance] %>
   option redispatch
   option forwardfor
   option httpchk GET <%= node[:haproxy][:health_check_url] %> # Nginx doesn't understand OPTIONS
   <% node[:haproxy][:static_backends].each do |backend| -%>
-  server <%= backend['name'] %> <%= backend['ip'] %>:80 weight <%= backend['backends'] || 10 %> maxconn <%= backend['backends'] * node[:haproxy][:maxcon_factor_static] %> check inter <%= node[:haproxy][:check_interval] %> 
+  server <%= backend['name'] %> <%= backend['ip'] %>:80 weight <%= backend['backends'] || 10 %> maxconn <%= backend['backends'] * node[:haproxy][:maxcon_factor_static] %> check inter <%= node[:haproxy][:check_interval] %> HTTP/1.0\r\nHost:\ <%= app_config[:domains].first %>
   <% end -%>
 <% end -%>
+<% end -%>
 
+<% node[:haproxy][:static_applications].each do |app_name, app_config| -%>
 <% if !node[:haproxy][:static_backends].empty? -%>  
-backend static_servers_ssl
+backend static_servers_ssl_<%= app_name %>
   mode tcp
   balance <%= node[:haproxy][:balance] %>
   option redispatch
@@ -130,6 +146,7 @@ backend static_servers_ssl
   <% node[:haproxy][:static_backends].each do |backend| -%>
   server <%= backend['name'] %> <%= backend['ip'] %>:443 weight <%= backend['backends'] || 10 %> maxconn <%= backend['backends'] * node[:haproxy][:maxcon_factor_static_ssl] %> check inter <%= node[:haproxy][:check_interval] %> 
   <% end -%>
+<% end -%>
 <% end -%>
   
 frontend http-in
@@ -180,9 +197,9 @@ frontend http-in
     <% node[:haproxy][:static_applications].each do |app_name, app_config| -%>
       <% app_config['domains'].each do |domain| -%>
         <% if app_config['mounted_at'] -%>
-  use_backend static_servers if static_application_<%= app_name %>_domain_<%= domain.gsub(/[^\w.:-]/, '_') %> static_application_<%= app_name %>_domain_<%= domain %>_path
+  use_backend static_servers_<%= app_name %> if static_application_<%= app_name %>_domain_<%= domain.gsub(/[^\w.:-]/, '_') %> static_application_<%= app_name %>_domain_<%= domain %>_path
         <% else -%>
-  use_backend static_servers if static_application_<%= app_name %>_domain_<%= domain.gsub(/[^\w.:-]/, '_') %>
+  use_backend static_servers_<%= app_name %> if static_application_<%= app_name %>_domain_<%= domain.gsub(/[^\w.:-]/, '_') %>
         <% end -%>
       <% end -%>
     <% end -%>
@@ -192,9 +209,9 @@ frontend http-in
     <% node[:haproxy][:nodejs_applications].each do |app_name, app_config| -%>
       <% app_config['domains'].each do |domain| -%>
         <% if app_config['mounted_at'] -%>
-  use_backend nodejs_app_servers if nodejs_application_<%= app_name %>_domain_<%= domain.gsub(/[^\w.:-]/, '_') %> nodejs_application_<%= app_name %>_domain_<%= domain %>_path
+  use_backend nodejs_app_servers_<%= app_name %> if nodejs_application_<%= app_name %>_domain_<%= domain.gsub(/[^\w.:-]/, '_') %> nodejs_application_<%= app_name %>_domain_<%= domain %>_path
         <% else -%>
-  use_backend nodejs_app_servers if nodejs_application_<%= app_name %>_domain_<%= domain.gsub(/[^\w.:-]/, '_') %>
+  use_backend nodejs_app_servers_<%= app_name %> if nodejs_application_<%= app_name %>_domain_<%= domain.gsub(/[^\w.:-]/, '_') %>
         <% end -%>
       <% end -%>
     <% end -%>
@@ -204,9 +221,9 @@ frontend http-in
     <% node[:haproxy][:php_applications].each do |app_name, app_config| -%>
       <% app_config['domains'].each do |domain| -%>
         <% if app_config['mounted_at'] -%>
-  use_backend php_app_servers if php_application_<%= app_name %>_domain_<%= domain.gsub(/[^\w.:-]/, '_') %> php_application_<%= app_name %>_domain_<%= domain %>_path
+  use_backend php_app_servers_<%= app_name %> if php_application_<%= app_name %>_domain_<%= domain.gsub(/[^\w.:-]/, '_') %> php_application_<%= app_name %>_domain_<%= domain %>_path
         <% else -%>
-  use_backend php_app_servers if php_application_<%= app_name %>_domain_<%= domain.gsub(/[^\w.:-]/, '_') %>
+  use_backend php_app_servers_<%= app_name %> if php_application_<%= app_name %>_domain_<%= domain.gsub(/[^\w.:-]/, '_') %>
         <% end -%>
       <% end -%>
     <% end -%>
@@ -216,23 +233,14 @@ frontend http-in
     <% node[:haproxy][:rails_applications].each do |app_name, app_config| -%>
       <% app_config['domains'].each do |domain| -%>
         <% if app_config['mounted_at'] -%>
-  use_backend rails_app_servers if rails_application_<%= app_name %>_domain_<%= domain.gsub(/[^\w.:-]/, '_') %> rails_application_<%= app_name %>_domain_<%= domain %>_path
+  use_backend rails_app_servers_<%= app_name %> if rails_application_<%= app_name %>_domain_<%= domain.gsub(/[^\w.:-]/, '_') %> rails_application_<%= app_name %>_domain_<%= domain %>_path
         <% else -%>
-  use_backend rails_app_servers if rails_application_<%= app_name %>_domain_<%= domain.gsub(/[^\w.:-]/, '_') %>
+  use_backend rails_app_servers_<%= app_name %> if rails_application_<%= app_name %>_domain_<%= domain.gsub(/[^\w.:-]/, '_') %>
         <% end -%>
       <% end -%>
     <% end -%>
   <% end -%>
     
-  <% if !node[:haproxy][:rails_backends].empty? -%>
-  default_backend rails_app_servers
-  <% elsif !node[:haproxy][:php_backends].empty? -%>
-  default_backend php_app_servers
-  <% elsif !node[:haproxy][:nodejs_backends].empty? -%>
-  default_backend nodejs_app_servers
-  <% elsif !node[:haproxy][:static_backends].empty? -%>
-  default_backend static_servers
-  <% end -%>
   
 frontend https-in
   mode tcp
@@ -241,52 +249,33 @@ frontend https-in
   # all domains of Rails applications
   <% node[:haproxy][:rails_applications].each do |app_name, app_config| -%>
     <% app_config['domains'].each do |domain| -%>
-  acl rails_applications_ssl hdr_end(host) -i <%= domain %>
+  acl rails_applications_ssl_<%= app_name %> hdr_end(host) -i <%= domain %>
     <% end -%>
+  use_backend rails_app_servers_ssl_<%= app_name %> if rails_applications_ssl_<%= app_name %>
   <% end -%>
 
   # all domains of PHP applications
   <% node[:haproxy][:php_applications].each do |app_name, app_config| -%>
     <% app_config['domains'].each do |domain| -%>
-  acl php_applications_ssl hdr_end(host) -i <%= domain %>
+  acl php_applications_ssl_<%= app_name %> hdr_end(host) -i <%= domain %>
     <% end -%>
+  use_backend php_app_servers_ssl_<%= app_name %> if php_applications_ssl_<%= app_name %>
   <% end -%>
 
   # all domains of node.js applications
   <% node[:haproxy][:nodejs_applications].each do |app_name, app_config| -%>
     <% app_config['domains'].each do |domain| -%>
-  acl nodejs_applications_ssl hdr_end(host) -i <%= domain %>
+  acl nodejs_applications_ssl_<%= app_name %> hdr_end(host) -i <%= domain %>
+  
     <% end -%>
+  use_backend nodejs_app_servers_ssl_<%= app_name %> if nodejs_applications_ssl_<%= app_name %>
   <% end -%>
   
   # all domains of static applications
   <% node[:haproxy][:static_applications].each do |app_name, app_config| -%>
     <% app_config['domains'].each do |domain| -%>
-  acl static_applications_ssl hdr_end(host) -i <%= domain %>
+  acl static_applications_ssl_<%= app_name %> hdr_end(host) -i <%= domain %>
     <% end -%>
+  use_backend static_servers_ssl_<%= app_name %> if static_applications_ssl_<%= app_name %>
   <% end -%>
-
-  <% unless node[:haproxy][:rails_applications].empty? || node[:haproxy][:rails_backends].empty? -%>
-  use_backend rails_app_servers_ssl if rails_applications_ssl
-  <% end -%>
-  <% unless node[:haproxy][:php_applications].empty? || node[:haproxy][:php_backends].empty? -%>
-  use_backend php_app_servers_ssl if php_applications_ssl
-  <% end -%>
-  <% unless node[:haproxy][:nodejs_applications].empty? || node[:haproxy][:nodejs_backends].empty? -%>
-  use_backend nodejs_app_servers_ssl if nodejs_applications_ssl
-  <% end -%>
-  <% unless node[:haproxy][:static_applications].empty? || node[:haproxy][:static_backends].empty? -%>
-  use_backend static_servers_ssl if static_applications_ssl
-  <% end -%>
-  
-  <% if !node[:haproxy][:rails_backends].empty? -%>
-  default_backend rails_app_servers_ssl
-  <% elsif !node[:haproxy][:php_backends].empty? -%>
-  default_backend php_app_servers_ssl
-  <% elsif !node[:haproxy][:nodejs_backends].empty? -%>
-  default_backend nodejs_app_servers_ssl
-  <% elsif !node[:haproxy][:static_backends].empty? -%>
-  default_backend static_servers_ssl
-  <% end -%>
-
 <% end -%>  

--- a/haproxy/templates/default/haproxy.cfg.erb
+++ b/haproxy/templates/default/haproxy.cfg.erb
@@ -278,22 +278,23 @@ frontend https-in
     <% end -%>
   use_backend static_servers_ssl_<%= app_name %> if static_applications_ssl_<%= app_name %>
   <% end -%>
-  
-  <% if !node[:haproxy][:rails_backends].empty? -%>
+
+  <% if !node[:haproxy][:rails_applications].empty? -%>
     <% node[:haproxy][:rails_applications].first do |app_name, app_config| -%>
   default_backend rails_app_servers_ssl_<%= app_name %>
     <% end -%>
-  <% elsif !node[:haproxy][:php_backends].empty? -%>
+  <% elsif !node[:haproxy][:php_applications].empty? -%>
     <% node[:haproxy][:php_applications].first do |app_name, app_config| -%>
   default_backend php_app_servers_ssl_<%= app_name %>
     <% end -%>
-  <% elsif !node[:haproxy][:nodejs_backends].empty? -%>
+  <% elsif !node[:haproxy][:nodejs_applications].empty? -%>
     <% node[:haproxy][:nodejs_applications].first do |app_name, app_config| -%>
   default_backend nodejs_app_servers_ssl_<%= app_name %>
     <% end -%>
-  <% elsif !node[:haproxy][:static_backends].empty? -%>
+  <% elsif !node[:haproxy][:static_applications].empty? -%>
     <% node[:haproxy][:static_applications].first do |app_name, app_config| -%>
   default_backend static_app_servers_ssl_<%= app_name %>
     <% end -%>
   <% end -%>
-<% end -%>  
+
+<% end -%>


### PR DESCRIPTION
This change will create separate backend for each application (whether it's nodejs, php or rails application). Each backend is monitored with it's hostname.

Previously if stack consisted of 10 apps and first app parsed by nginx was returning 400 or 500, whole backend for 10 apps was marked as DOWN.
