### PR TITLE
how did this thing disappear, is this even working then?

### DIFF
--- a/opsworks_custom_cookbooks/libraries/include_recipe_for_ruby_blocks.rb
+++ b/opsworks_custom_cookbooks/libraries/include_recipe_for_ruby_blocks.rb
@@ -1,0 +1,16 @@
+class Chef::Resource::RubyBlock
+    include Chef::Mixin::LanguageIncludeRecipe
+    include Chef::Mixin::LanguageIncludeAttribute
+
+    def load_new_cookbooks
+        Chef::Log.info("Loading custom cookbooks")
+        new_cookbook_collection = Chef::CookbookCollection.new(Chef::CookbookLoader.new)
+        node.cookbook_collection = new_cookbook_collection
+
+        run_context = self.is_a?(Chef::RunContext) ? self : self.run_context
+        run_context.instance_variable_set("@cookbook_collection", new_cookbook_collection)
+        run_context.load
+
+        node.load_attributes
+    end
+end


### PR DESCRIPTION
restore the library file removed in 
https://github.com/aws/opsworks-cookbooks/commit/8808a87ce7ad5b9d7dde322c6be2d082efcaffe1

I believe this has been ok because opsworks-custom-cookbooks is called with
`include_recipe "opsworks-custom-cookbooks::execute"` or something or other...
