### PR TITLE
Reverted notification style for restarting rails

### DIFF
--- a/rails/recipes/configure.rb
+++ b/rails/recipes/configure.rb
@@ -20,7 +20,7 @@ node[:deploy].each do |application, deploy|
     owner deploy[:user]
     variables(:database => deploy[:database], :environment => deploy[:rails_env])
 
-    notifies :run, "execute[restart Rails app #{application}]"
+    notifies :run, resources(:execute => "restart Rails app #{application}")
 
     only_if do
       File.exists?("#{deploy[:deploy_to]}") && File.exists?("#{deploy[:deploy_to]}/shared/config/")
@@ -38,7 +38,7 @@ node[:deploy].each do |application, deploy|
       :environment => deploy[:rails_env]
     )
 
-    notifies :run, "execute[restart Rails app #{application}]"
+    notifies :run, resources(:execute => "restart Rails app #{application}")
 
     only_if do
       File.exists?("#{deploy[:deploy_to]}") && File.exists?("#{deploy[:deploy_to]}/shared/config/")


### PR DESCRIPTION
Currently rails deploys are broken in Chef 11 because there are spaces in the resource name breaking the notify that's triggered when updating database.yml.

This change modifies the rails restart notify to use the old notify syntax, which unlike the new syntax works with spaces in the resource name.

(even if we modified the 'restart Rails app' part of the resource name to remove the spaces, the resource name also includes the app name which may also have spaces)
