### PR TITLE
Make sure that the right data is present during the mysql deployment.

### DIFF
--- a/deploy/recipes/mysql.rb
+++ b/deploy/recipes/mysql.rb
@@ -2,6 +2,8 @@ require 'resolv'
 include_recipe 'deploy'
 
 node[:deploy].each do |application, deploy|
+  next unless deploy[:database]
+  
   mysql_command = "/usr/bin/mysql -u #{deploy[:database][:username]} #{node[:mysql][:server_root_password].blank? ? '' : "-p#{node[:mysql][:server_root_password]}"}"
 
   execute "create mysql database" do


### PR DESCRIPTION
Otherwise this can throw "NoMethodError - undefined method `[]' for nil:NilClass - /opt/aws/opsworks/releases/20131015111601_209/cookbooks/deploy/recipes/mysql.rb:5:in`from_file'" errors when you've got multiple applications running on one stack, and are using custom JSON to override the deploy recipe for one of them (node[:deploy] will have multiple apps, but only one of them will contain all the necessary information for the deployment).
