### PR TITLE
Run bundle as the config user instead of hardcoding to 'deploy'

### DIFF
--- a/rails/libraries/rails_configuration.rb
+++ b/rails/libraries/rails_configuration.rb
@@ -37,8 +37,8 @@ module OpsWorks
     def self.bundle(app_name, app_config, app_root_path)
       if File.exists?("#{app_root_path}/Gemfile")
         Chef::Log.info("Gemfile detected. Running bundle install.")
-        Chef::Log.info("sudo su deploy -c 'cd #{app_root_path} && /usr/local/bin/bundle install --path #{app_config[:home]}/.bundler/#{app_name} --without=#{app_config[:ignore_bundler_groups].join(' ')}'")
-        Chef::Log.info(`sudo su deploy -c 'cd #{app_root_path} && /usr/local/bin/bundle install --path #{app_config[:home]}/.bundler/#{app_name} --without=#{app_config[:ignore_bundler_groups].join(' ')} 2>&1'`)
+        Chef::Log.info("sudo su #{app_config[:user]} -c 'cd #{app_root_path} && /usr/local/bin/bundle install --path #{app_config[:home]}/.bundler/#{app_name} --without=#{app_config[:ignore_bundler_groups].join(' ')}'")
+        Chef::Log.info(`sudo su #{app_config[:user]} -c 'cd #{app_root_path} && /usr/local/bin/bundle install --path #{app_config[:home]}/.bundler/#{app_name} --without=#{app_config[:ignore_bundler_groups].join(' ')} 2>&1'`)
       end
     end
   end


### PR DESCRIPTION
Currently **bundle** is being run as the **deploy** user while the install path for bundler is set to the configured home directory. If we use a custom user for deployment, then the home directory will be the custom user's home directory, but the hard-coded _deploy_ user won't have permissions to copy anything there & the bundle will fail. Hence we need to use the custom deployment user while running _bundle_ - if no custom user is specified, this defaults to the _deploy_ user anyway.
