### PR TITLE
Fix bizarre error when “configuring” multiple PHP Apps

### DIFF
--- a/mod_php5_apache2/attributes/default.rb
+++ b/mod_php5_apache2/attributes/default.rb
@@ -1,3 +1,5 @@
+include_attribute 'deploy'
+
 packages = []
 
 case node[:platform_family]


### PR DESCRIPTION
Leaving the "DocumentRoot" empty.

DocumentRoot <%= @params[:docroot] %>

PS: Support Case ID 123158551

Fixes #76
