### PR TITLE
Bugfix: Correct Deploy User for npm install

### DIFF
--- a/opsworks_nodejs/libraries/nodejs_configuration.rb
+++ b/opsworks_nodejs/libraries/nodejs_configuration.rb
@@ -3,7 +3,7 @@ module OpsWorks
     def self.npm_install(app_name, app_config, app_root_path)
       if File.exists?("#{app_root_path}/package.json")
         Chef::Log.info("package.json detected. Running npm install.")
-        Chef::Log.info(`sudo su deploy -c 'cd #{app_root_path} && npm install' 2>&1`)
+        Chef::Log.info(`sudo su #{app_config[:user]} -c 'cd #{app_root_path} && npm install' 2>&1`)
       end
     end
   end

--- a/opsworks_nodejs/libraries/nodejs_configuration.rb
+++ b/opsworks_nodejs/libraries/nodejs_configuration.rb
@@ -3,7 +3,7 @@ module OpsWorks
     def self.npm_install(app_name, app_config, app_root_path)
       if File.exists?("#{app_root_path}/package.json")
         Chef::Log.info("package.json detected. Running npm install.")
-        Chef::Log.info(`sudo su deploy -c 'cd #{app_root_path} && npm install 2>&1'`)
+        Chef::Log.info(`sudo su deploy -c 'cd #{app_root_path} && npm install' 2>&1`)
       end
     end
   end


### PR DESCRIPTION
The current npm install does not use the correct user for sudo, it has 'deploy' hardcoded.

Additional change: The statement does not show stderr output of the sudo command in the logs, fixed.

I ran today in a bug where user 'deploy' was not existing on the machine - showing the related sudo error message in the logs would have reduced my debugging time signifcant ;)
