### PR TITLE
removed 'text/html' from nginx gzip_types as added by default

### DIFF
--- a/nginx/attributes/nginx.rb
+++ b/nginx/attributes/nginx.rb
@@ -24,7 +24,6 @@ default[:nginx][:gzip_http_version] = '1.0'
 default[:nginx][:gzip_comp_level] = '2'
 default[:nginx][:gzip_proxied] = 'any'
 default[:nginx][:gzip_types] = ['text/plain',
-                                'text/html',
                                 'text/css',
                                 'application/x-javascript',
                                 'text/xml',


### PR DESCRIPTION
I have removed 'text/html' from nginx gzip_types as its added by default.   When you try to restart nginx with service nginx restart command you get a nginx: [warn] duplicate MIME type "text/html" in /etc/nginx/nginx.conf warning.
