### PR TITLE
adding metadata.rb for unicorn as it was missing

### DIFF
--- a/unicorn/metadata.rb
+++ b/unicorn/metadata.rb
@@ -1,0 +1,9 @@
+maintainer        "Opscode, Inc."
+maintainer_email  "cookbooks@opscode.com"
+license           "Apache 2.0"
+description       "Manage unicorn"
+version           "0.1"
+
+%w{ ubuntu debian }.each do |os|
+  supports os
+end


### PR DESCRIPTION
I would like to use Berkshelf to source these cookbooks for use on OpsWorks which requires having a metadata.rb in each cookbook.
