### PR TITLE
Add OpsWorks Custom Layer Hosts (/etc/hosts)

### DIFF
--- a/opsworks_stack_state_sync/templates/default/hosts.erb
+++ b/opsworks_stack_state_sync/templates/default/hosts.erb
@@ -28,7 +28,7 @@ ff02::3 ip6-allhosts
 
 # OpsWorks Custom Layer Hosts
 <% node[:opsworks][:instance][:layers].each do |layer_name| -%>
-    <% continue if !node[:opsworks][:layers][layer_name].has_key?(:hosts) -%>
+    <% next if !node[:opsworks][:layers][layer_name].has_key?(:hosts) -%>
     <% node[:opsworks][:layers][layer_name][:hosts].each do |ip, entry| -%>
         <%= ip %> <%= entry %>
     <% end -%>

--- a/opsworks_stack_state_sync/templates/default/hosts.erb
+++ b/opsworks_stack_state_sync/templates/default/hosts.erb
@@ -25,3 +25,11 @@ ff02::3 ip6-allhosts
 <% end -%>
 <% end -%>
 <% end -%>
+
+# OpsWorks Custom Layer Hosts
+<% node[:opsworks][:instance][:layers].each do |layer_name| -%>
+    <% continue if !node[:opsworks][:layers][layer_name].has_key?(:hosts) -%>
+    <% node[:opsworks][:layers][layer_name][:hosts].each do |ip, entry| -%>
+        <%= ip %> <%= entry %>
+    <% end -%>
+<% end -%>


### PR DESCRIPTION
We need the ability to define hosts entries per layer. Here is a pull request as this already has been requested (https://github.com/aws/opsworks-cookbooks/issues/51).

``` json
{
    "opsworks": {
        "layers": {
            "app": {
                "hosts": {
                    "127.0.0.1": "foobar.com.au"
                }
            }
        }
    }
}
```

Result:

``` bash
$ cat /etc/hosts
# This file was generated by OpsWorks
# any manual changes will be removed on the next update.

127.0.0.1 localhost localhost.localdomain

# The following lines are desirable for IPv6 capable hosts
# ...

# OpsWorks Layer State
127.0.0.1 test.localdomain test
11.11.0.111 app1
33.444.77.99 app1-ext

# Custom layer hostnames
127.0.0.1 foobar.com.au
```
