### PR TITLE
Fix setup step failure for Java App Server layers

### DIFF
--- a/apache2/recipes/default.rb
+++ b/apache2/recipes/default.rb
@@ -55,6 +55,12 @@ if platform?('centos', 'redhat', 'fedora', 'amazon')
     action :create
   end
 
+  directory '/usr/local/bin'  do
+    mode 0755
+    action :create
+    recursive true
+  end
+
   cookbook_file '/usr/local/bin/apache2_module_conf_generate.pl' do
     source 'apache2_module_conf_generate.pl'
     mode 0755

--- a/ruby/attributes/ruby.rb
+++ b/ruby/attributes/ruby.rb
@@ -6,7 +6,7 @@ case node["opsworks"]["ruby_version"]
 when "2.0.0"
   default[:ruby][:major_version] = '2.0'
   default[:ruby][:full_version] = '2.0.0'
-  default[:ruby][:patch] = 'p247'
+  default[:ruby][:patch] = 'p353'
   default[:ruby][:pkgrelease] = '1'
 when "1.9.3"
   default[:ruby][:major_version] = '1.9'


### PR DESCRIPTION
If I create a Java App Server layer with these settings:
 Java version: OpenJDK 7
 Java stack: Tomcat 7
 Java VM options: none
 Cutsom Chef Recipes: none

Instances started in this layer fail at the setup step. Log output is https://gist.github.com/amdg/8452033

This patch ensures that /usr/local/bin exists before creating a file inside it.
