### PR TITLE
Include pool size in database.yml.erb

### DIFF
--- a/rails/templates/default/database.yml.erb
+++ b/rails/templates/default/database.yml.erb
@@ -10,5 +10,11 @@
 <% if @database[:port] -%>
   port: <%= @database[:port].to_i.inspect %>
 <% end -%>
+<% if @database[:pool] -%>
+  pool: <%= @database[:pool].to_i.inspect %>
+<% end -%>
+<% if @database[:wait_timeout] -%>
+  wait_timeout: <%= @database[:wait_timeout].to_i.inspect %>
+<% end -%>
 
 <% end %>


### PR DESCRIPTION
We need pool size in the database.yml.erb otherwise we run out of database connections when scaling.
