### PR TITLE
Point callback file to shared directory structure for application. Create shared deploy directory

### DIFF
--- a/deploy/definitions/opsworks_deploy.rb
+++ b/deploy/definitions/opsworks_deploy.rb
@@ -142,7 +142,7 @@ define :opsworks_deploy do
         end
 
         # run user provided callback file
-        run_callback_from_file("#{release_path}/deploy/before_migrate.rb")
+        run_callback_from_file("#{node[:deploy][application][:deploy_to]}/shared/deploy/before_migrate.rb")
       end
     end
   end

--- a/deploy/definitions/opsworks_deploy_dir.rb
+++ b/deploy/definitions/opsworks_deploy_dir.rb
@@ -9,7 +9,7 @@ define :opsworks_deploy_dir do
   end
 
   # create shared/ directory structure
-  ['log','config','system','pids','scripts','sockets'].each do |dir_name|
+  ['deploy','log','config','system','pids','scripts','sockets'].each do |dir_name|
     directory "#{params[:path]}/shared/#{dir_name}" do
       group params[:group]
       owner params[:user]


### PR DESCRIPTION
This request is due to the need for before_migrate actions needing to be run prior to the symlink being created for the newly deployed app, but being unable to place the needed before_migrate file into the release path directory before it's symlinked. The issue is that the release path is only created when opsworks_deploy is called, and by that time it makes it difficult to place the before_migrate.rb file in a deploy directory before it completes the deploy. I was also unable to use the release_path variable as it seems to be created during this definition run. I was unable to successfully execute a before_migrate.rb call without this config update. This config change allows for this to work as expected:
# Creates required directory structure to execute Opsworks Deploy

node[:deploy].each do |application, deploy|
  opsworks_deploy_dir do
    group deploy[:group]
    path deploy[:deploy_to]
  end
end

template "#{deploy_dir}/shared/deploy/before_migrate.rb" do
  source "before_migrate.rb"
end

node[:deploy].each do |application, deploy|
  opsworks_deploy do
    deploy_data deploy
    app application
  end
end
