### PR TITLE
Skip rails::configure for non-rails applications

### DIFF
--- a/rails/recipes/configure.rb
+++ b/rails/recipes/configure.rb
@@ -3,7 +3,7 @@ include_recipe "deploy"
 node[:deploy].each do |application, deploy|
 
   if deploy[:application_type] != 'rails'
-    Chef::Log.debug("Skipping deploy::rails application #{application} as it is not an Rails app")
+    Chef::Log.debug("Skipping rails::configure application #{application} as it is not an Rails app")
     next
   end
 

--- a/rails/recipes/configure.rb
+++ b/rails/recipes/configure.rb
@@ -1,7 +1,11 @@
 include_recipe "deploy"
 
 node[:deploy].each do |application, deploy|
-  deploy = node[:deploy][application]
+
+  if deploy[:application_type] != 'rails'
+    Chef::Log.debug("Skipping deploy::rails application #{application} as it is not an Rails app")
+    next
+  end
 
   execute "restart Rails app #{application}" do
     cwd deploy[:current_path]


### PR DESCRIPTION
This change prevents the rails::configure recipe from
attempting to restart non-rails applications deployed
on the same instance.

The same solution is used in the other app server configure
recipes- php::configure, opsworks_nodejs::configure and
opsworks_java::context
