### PR TITLE
Added the PORT environment variable to nodejs invocation

### DIFF
--- a/opsworks_nodejs/templates/default/node_web_app.monitrc.erb
+++ b/opsworks_nodejs/templates/default/node_web_app.monitrc.erb
@@ -1,5 +1,5 @@
 check host node_web_app_<%= @application_name %> with address 127.0.0.1
-  start program = "/bin/sh -c 'cd <%= @deploy[:deploy_to] %>/current; /usr/bin/env NODE_PATH=<%= @deploy[:deploy_to] %>/current/node_modules:<%= @deploy[:deploy_to] %>/current /usr/local/bin/node <%= @monitored_script %>'"
+  start program = "/bin/sh -c 'cd <%= @deploy[:deploy_to] %>/current; /usr/bin/env PORT=80 NODE_PATH=<%= @deploy[:deploy_to] %>/current/node_modules:<%= @deploy[:deploy_to] %>/current /usr/local/bin/node <%= @monitored_script %>'"
   stop program  = "/usr/bin/pkill -f 'node <%= @monitored_script %>'"
   if failed port 80 protocol HTTP
     request /


### PR DESCRIPTION
Added the PORT environment variable to nodejs invocation to support the more standard:

`app.set('port', process.env.PORT || 3000);`

Rather than hard coding it.  Since the check below explicitly checks for port 80, I did not make it configurable to 443 due to the check for port 80 - though it should be.
