### PR TITLE
Add environment variables for node deployments from "Custom Chef JSON" config

### DIFF
--- a/deploy/definitions/opsworks_nodejs.rb
+++ b/deploy/definitions/opsworks_nodejs.rb
@@ -2,6 +2,14 @@ define :opsworks_nodejs do
   deploy = params[:deploy_data]
   application = params[:app]
 
+  env_vars = Array.new
+  unless node[:custom_env].nil?
+    node[:custom_env].each do |k, v|
+      env_vars.push("#{k}=#{v}")
+      Chef::Log.info("Added environment variable: #{k}=#{v}")
+    end
+  end
+
   service 'monit' do
     action :nothing
   end
@@ -28,6 +36,7 @@ define :opsworks_nodejs do
     group 'root'
     mode '0644'
     variables(
+      :environment_vars => env_vars.join(' '),
       :deploy => deploy,
       :application_name => application,
       :monitored_script => "#{deploy[:deploy_to]}/current/server.js"

--- a/opsworks_nodejs/templates/default/node_web_app.monitrc.erb
+++ b/opsworks_nodejs/templates/default/node_web_app.monitrc.erb
@@ -1,5 +1,5 @@
 check host node_web_app_<%= @application_name %> with address 127.0.0.1
-  start program = "/bin/sh -c 'cd <%= @deploy[:deploy_to] %>/current; /usr/bin/env NODE_PATH=<%= @deploy[:deploy_to] %>/current/node_modules:<%= @deploy[:deploy_to] %>/current /usr/local/bin/node <%= @monitored_script %>'"
+  start program = "/bin/sh -c 'cd <%= @deploy[:deploy_to] %>/current; /usr/bin/env NODE_PATH=<%= @deploy[:deploy_to] %>/current/node_modules:<%= @deploy[:deploy_to] %>/current <%= @environment_vars %> /usr/local/bin/node <%= @monitored_script %> 2>> <%= @deploy[:deploy_to] %>/current/log/error.log 1>> <%= @deploy[:deploy_to] %>/current/log/server.log'"
   stop program  = "/usr/bin/pkill -f 'node <%= @monitored_script %>'"
   if failed port 80 protocol HTTP
     request /


### PR DESCRIPTION
Follow up on #65, separating @gouldingken's implementation for a `custom_env` config object.
