### PR TITLE
Update rails cookbook bundler command to simulate a full login for the deploy user

### DIFF
--- a/rails/libraries/rails_configuration.rb
+++ b/rails/libraries/rails_configuration.rb
@@ -37,8 +37,8 @@ module OpsWorks
     def self.bundle(app_name, app_config, app_root_path)
       if File.exists?("#{app_root_path}/Gemfile")
         Chef::Log.info("Gemfile detected. Running bundle install.")
-        Chef::Log.info("sudo su #{app_config[:user]} -c 'cd #{app_root_path} && /usr/local/bin/bundle install --path #{app_config[:home]}/.bundler/#{app_name} --without=#{app_config[:ignore_bundler_groups].join(' ')}'")
-        Chef::Log.info(`sudo su #{app_config[:user]} -c 'cd #{app_root_path} && /usr/local/bin/bundle install --path #{app_config[:home]}/.bundler/#{app_name} --without=#{app_config[:ignore_bundler_groups].join(' ')} 2>&1'`)
+        Chef::Log.info("sudo su - #{app_config[:user]} -c 'cd #{app_root_path} && /usr/local/bin/bundle install --path #{app_config[:home]}/.bundler/#{app_name} --without=#{app_config[:ignore_bundler_groups].join(' ')}'")
+        Chef::Log.info(`sudo su - #{app_config[:user]} -c 'cd #{app_root_path} && /usr/local/bin/bundle install --path #{app_config[:home]}/.bundler/#{app_name} --without=#{app_config[:ignore_bundler_groups].join(' ')} 2>&1'`)
       end
     end
   end


### PR DESCRIPTION
I'm trying to utilize the Ruby Java Bridge (rjb) gem which has a compile dependency on the JAVA_HOME environment variable.  I've been able to get the setting included in the 'deploy' user's shell environment using the java::set_java_home recipe but it's not sticking due to the way we call the bundler.  The change I'm asking for solves the problem for me.
