### PR TITLE
Fix too open wide UNIX permissions on deploy_dir and the release itself

### DIFF
--- a/deploy/definitions/opsworks_deploy.rb
+++ b/deploy/definitions/opsworks_deploy.rb
@@ -5,9 +5,13 @@ define :opsworks_deploy do
   directory "#{deploy[:deploy_to]}" do
     group deploy[:group]
     owner deploy[:user]
-    mode "0775"
+    mode "0770"
     action :create
     recursive true
+  end
+
+  directory "#{deploy[:deploy_to]}/releases" do
+    mode "0770"
   end
 
   if deploy[:scm]


### PR DESCRIPTION
When deploying Rails Apps, the permissions of the shared directory look (correctly) like:

drwxrwx--- 9 deploy www-data 4096 Mar  3 11:37 /srv/www/app/shared/

… which is defined in deploy/definitions/opsworks_deploy_dir.rb (mode 0770)

The Application itself (and the whole deploy_to dir) rather has too open wide permissions:

drwxr-xr-x 17 deploy www-data 4096 Mar  2 20:59 /srv/www/app/releases/20140302195538/

So no 0770 here, rather 0777, which leads to the effect that every user on the machine can view important files like config/initializers/secret_token.rb.

That's why the permissions of the whole directory should be 0770. This pull request fixes that.
