### PR TITLE
Add support for node env for express

### DIFF
--- a/deploy/attributes/deploy.rb
+++ b/deploy/attributes/deploy.rb
@@ -89,6 +89,7 @@ node[:deploy].each do |application, deploy|
   # nodejs
   default[:deploy][application][:nodejs][:restart_command] = "monit restart node_web_app_#{application}"
   default[:deploy][application][:nodejs][:stop_command] = "monit stop node_web_app_#{application}"
+  default[:deploy][application][:node_env] = 'production'
 end
 
 default[:opsworks][:skip_uninstall_of_other_rails_stack] = false

--- a/deploy/definitions/opsworks_nodejs.rb
+++ b/deploy/definitions/opsworks_nodejs.rb
@@ -30,7 +30,8 @@ define :opsworks_nodejs do
     variables(
       :deploy => deploy,
       :application_name => application,
-      :monitored_script => "#{deploy[:deploy_to]}/current/server.js"
+      :monitored_script => "#{deploy[:deploy_to]}/current/server.js",
+      :node_env => "#{node.default[:deploy][application][:node_env]}"
     )
     notifies :restart, "service[monit]", :immediately
   end

--- a/deploy/definitions/opsworks_nodejs.rb
+++ b/deploy/definitions/opsworks_nodejs.rb
@@ -31,7 +31,7 @@ define :opsworks_nodejs do
       :deploy => deploy,
       :application_name => application,
       :monitored_script => "#{deploy[:deploy_to]}/current/server.js",
-      :node_env => "#{node.default[:deploy][application][:node_env]}"
+      :node_env => node[:deploy][application][:node_env]
     )
     notifies :restart, "service[monit]", :immediately
   end

--- a/opsworks_nodejs/templates/default/node_web_app.monitrc.erb
+++ b/opsworks_nodejs/templates/default/node_web_app.monitrc.erb
@@ -1,5 +1,5 @@
 check host node_web_app_<%= @application_name %> with address 127.0.0.1
-  start program = "/bin/sh -c 'cd <%= @deploy[:deploy_to] %>/current; /usr/bin/env NODE_PATH=<%= @deploy[:deploy_to] %>/current/node_modules:<%= @deploy[:deploy_to] %>/current /usr/local/bin/node <%= @monitored_script %>'"
+  start program = "/bin/sh -c 'cd <%= @deploy[:deploy_to] %>/current; /usr/bin/env NODE_ENV=<%= @deploy[:node_env] %> NODE_PATH=<%= @deploy[:deploy_env] %>/current/node_modules:<%= @deploy[:deploy_to] %>/current /usr/local/bin/node <%= @monitored_script %>'"
   stop program  = "/usr/bin/pkill -f 'node <%= @monitored_script %>'"
   if failed port 80 protocol HTTP
     request /

--- a/opsworks_nodejs/templates/default/node_web_app.monitrc.erb
+++ b/opsworks_nodejs/templates/default/node_web_app.monitrc.erb
@@ -1,5 +1,5 @@
 check host node_web_app_<%= @application_name %> with address 127.0.0.1
-  start program = "/bin/sh -c 'cd <%= @deploy[:deploy_to] %>/current; /usr/bin/env NODE_ENV=<%= @deploy[:node_env] %> NODE_PATH=<%= @deploy[:deploy_env] %>/current/node_modules:<%= @deploy[:deploy_to] %>/current /usr/local/bin/node <%= @monitored_script %>'"
+  start program = "/bin/sh -c 'cd <%= @deploy[:deploy_to] %>/current; /usr/bin/env NODE_ENV=<%= @node_env %> NODE_PATH=<%= @deploy[:deploy_to] %>/current/node_modules:<%= @deploy[:deploy_to] %>/current /usr/local/bin/node <%= @monitored_script %>'"
   stop program  = "/usr/bin/pkill -f 'node <%= @monitored_script %>'"
   if failed port 80 protocol HTTP
     request /


### PR DESCRIPTION
Node JS framework express finds it useful to have NODE_ENV variable set. The modifications made allow for this to be done. The default production value is set. It can be overwritten via custom json. 
