### PR TITLE
Add X-Request-Start header for NewRelic request queuing reporting

### DIFF
--- a/unicorn/templates/default/nginx_unicorn_web_app.erb
+++ b/unicorn/templates/default/nginx_unicorn_web_app.erb
@@ -27,6 +27,7 @@ server {
   location / {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
+    proxy_set_header X-Request-Start "t=${msec}";
     proxy_redirect off;
 
   <% if node[:nginx] && node[:nginx][:proxy_read_timeout] -%>
@@ -82,6 +83,7 @@ server {
     proxy_set_header X-Forwarded-Proto https;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
+    proxy_set_header X-Request-Start "t=${msec}";
     proxy_redirect off;
 
   <% if node[:nginx] && node[:nginx][:proxy_read_timeout] -%>

--- a/unicorn/templates/default/nginx_unicorn_web_app.erb
+++ b/unicorn/templates/default/nginx_unicorn_web_app.erb
@@ -27,7 +27,11 @@ server {
   location / {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
-    proxy_set_header X-Request-Start "t=${msec}";
+
+    <% if ['centos','redhat','fedora','amazon'].include?(node[:platform]) %>
+      proxy_set_header X-Request-Start "t=${msec}";
+    <% end %>
+
     proxy_redirect off;
 
   <% if node[:nginx] && node[:nginx][:proxy_read_timeout] -%>
@@ -83,7 +87,11 @@ server {
     proxy_set_header X-Forwarded-Proto https;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
-    proxy_set_header X-Request-Start "t=${msec}";
+
+    <% if ['centos','redhat','fedora','amazon'].include?(node[:platform]) %>
+      proxy_set_header X-Request-Start "t=${msec}";
+    <% end %>
+
     proxy_redirect off;
 
   <% if node[:nginx] && node[:nginx][:proxy_read_timeout] -%>


### PR DESCRIPTION
This enables NewRelic request queueing reporting for nginx/unicorn webapps. See https://docs.newrelic.com/docs/features/request-queue-server-configuration-examples#nginx

My contribution is provided under the Apache 2.0 license.
