### PR TITLE
Allow setting of sslca in Rails database.yml via custom JSON

### DIFF
--- a/rails/templates/default/database.yml.erb
+++ b/rails/templates/default/database.yml.erb
@@ -13,5 +13,8 @@
 <% if @database[:port] -%>
   port: <%= @database[:port].to_i.inspect %>
 <% end -%>
+<% if @database[:sslca] -%>
+  sslca: <%= @database[:sslca].to_s.inspect %>
+<% end -%>
 
 <% end %>


### PR DESCRIPTION
Sometimes (e.g. with Amazon RDS) you need to specify the CA certificate path if using SSL connections.
