### PR TITLE
Added create_dirs_before_symlink to possible deploy custom json settings

### DIFF
--- a/deploy/attributes/deploy.rb
+++ b/deploy/attributes/deploy.rb
@@ -95,6 +95,7 @@ node[:deploy].each do |application, deploy|
   default[:deploy][application][:enable_submodules] = true
   default[:deploy][application][:shallow_clone] = false
   default[:deploy][application][:delete_cached_copy] = true
+  default[:deploy][application][:create_dirs_before_symlink] = %w{tmp public config}
   default[:deploy][application][:symlink_before_migrate] = {}
 
   default[:deploy][application][:environment] = {"RAILS_ENV" => deploy[:rails_env],

--- a/deploy/definitions/opsworks_deploy.rb
+++ b/deploy/definitions/opsworks_deploy.rb
@@ -74,6 +74,7 @@ define :opsworks_deploy do
       migrate deploy[:migrate]
       migration_command deploy[:migrate_command]
       environment deploy[:environment].to_hash
+      create_dirs_before_symlink( deploy[:create_dirs_before_symlink] )
       symlink_before_migrate( deploy[:symlink_before_migrate] )
       action deploy[:action]
 


### PR DESCRIPTION
As per documentation here : http://docs.opscode.com/resource_deploy.html

Allows creating folders in which you can create symlinks and avoid a "No such file or directory" error. By default, reuses Chef's default folders tmp, public and config. For example, in the deploy section of my json :

```
"create_dirs_before_symlink": [
        "tmp",
        "public",
        "config",
        "tmp/cache/assets/staging/"
      ],
      "symlink_before_migrate": {
        "sprockets":"tmp/cache/assets/staging/",
      }
```

I have tested setting the value as shown above, as well as leaving it emtpy to use defaults. 
