### PR TITLE
Simplify adding locations to unicorn nginx config

### DIFF
--- a/unicorn/templates/default/nginx_unicorn_web_app.erb
+++ b/unicorn/templates/default/nginx_unicorn_web_app.erb
@@ -60,7 +60,7 @@ server {
   listen   443;
   server_name <%= @application[:domains].join(" ") %> <%= node[:hostname] %>;
   access_log <%= node[:nginx][:log_dir] %>/<%= @application[:domains].first %>-ssl.access.log;
-  
+
   ssl on;
   ssl_certificate /etc/nginx/ssl/<%= @application[:domains].first %>.crt;
   ssl_certificate_key /etc/nginx/ssl/<%= @application[:domains].first %>.key;

--- a/unicorn/templates/default/nginx_unicorn_web_app.erb
+++ b/unicorn/templates/default/nginx_unicorn_web_app.erb
@@ -23,6 +23,12 @@ server {
   <% end %>
 
   location / {
+    # If you don't find the filename in the static files
+    # Then request it from the unicorn server
+    try_files $uri @unicorn;
+  }
+
+  location @unicorn {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
     proxy_redirect off;
@@ -34,12 +40,7 @@ server {
     proxy_send_timeout <%= node[:nginx][:proxy_send_timeout] %>;
   <% end -%>
 
-    # If you don't find the filename in the static files
-    # Then request it from the unicorn server
-    if (!-f $request_filename) {
-      proxy_pass http://unicorn_<%= @application[:domains].first %>;
-      break;
-    }
+    proxy_pass http://unicorn_<%= @application[:domains].first %>;
   }
 
   location /nginx_status {
@@ -77,6 +78,12 @@ server {
   <% end %>
 
   location / {
+    # If you don't find the filename in the static files
+    # Then request it from the unicorn server
+    try_files $uri @unicorn;
+  }
+
+  location @unicorn {
     proxy_set_header X-Forwarded-Proto https;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
@@ -89,12 +96,7 @@ server {
     proxy_send_timeout <%= node[:nginx][:proxy_send_timeout] %>;
   <% end -%>
 
-    # If you don't find the filename in the static files
-    # Then request it from the unicorn server
-    if (!-f $request_filename) {
-      proxy_pass http://unicorn_<%= @application[:domains].first %>;
-      break;
-    }
+    proxy_pass http://unicorn_<%= @application[:domains].first %>;
   }
 
   error_page 500 502 503 504 /500.html;


### PR DESCRIPTION
For a modern rails app you might want to add additional cache control
headers to for example /assets, this reworks how the passing to unicorn
works to simplify such additions.

This is a incremental step towards fixing #114
