### PR TITLE
Only include yum packages on YUM platforms

### DIFF
--- a/opsworks_initial_setup/recipes/default.rb
+++ b/opsworks_initial_setup/recipes/default.rb
@@ -6,9 +6,12 @@ include_recipe 'opsworks_initial_setup::vol_mount_point'
 include_recipe 'opsworks_initial_setup::remove_landscape'
 include_recipe 'opsworks_initial_setup::ldconfig'
 
+case node["platform_family"]
+when "rhel"
 include_recipe 'opsworks_initial_setup::yum_conf'
 include_recipe 'opsworks_initial_setup::tweak_chef_yum_dump'
 include_recipe 'opsworks_initial_setup::setup_rhel_repos'
+end
 
 include_recipe 'opsworks_initial_setup::package_procps'
 include_recipe 'opsworks_initial_setup::package_ntpd'


### PR DESCRIPTION
It is unnecessary to include the yum cookbook on Ubuntu systems and often causes hard to trace constraint issues on Ubuntu/Debian-servers such as:
# 
# Error Resolving Cookbooks for Run List:
## Missing Cookbooks:

Could not satisfy version constraints for: yum
## Expanded Run List:
- opsworks_initial_setup
- ssh_host_keys
- ssh_users
- mysql::client
- dependencies
- ebs
- opsworks_ganglia::client
- opsworks_stack_state_sync
- rabbitmq_cluster
- deploy::default
- test_suite
- opsworks_cleanup

[2014-06-16T18:17:43+00:00] ERROR: Running exception handlers
[2014-06-16T18:17:43+00:00] ERROR: Exception handlers complete
[2014-06-16T18:17:43+00:00] FATAL: Stacktrace dumped to /var/lib/aws/opsworks/cache/chef-stacktrace.out
[2014-06-16T18:17:43+00:00] ERROR: 412 "Precondition Failed"
[2014-06-16T18:17:43+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
