### PR TITLE
Allow deploy_to to override application install location

### DIFF
--- a/deploy/recipes/rails-undeploy.rb
+++ b/deploy/recipes/rails-undeploy.rb
@@ -52,7 +52,7 @@ node[:deploy].each do |application, deploy|
 
     execute 'stop unicorn and restart nginx' do
       command "sleep #{deploy[:sleep_before_restart]} && \
-               /srv/www/#{application}/shared/scripts/unicorn stop"
+               #{deploy[:deploy_to]}/shared/scripts/unicorn stop"
       notifies :restart, "service[nginx]"
       action :run
     end


### PR DESCRIPTION
Currently every other reference to /srv/www in the context of
application deployment is configurable. Adjusting the :deploy_to
configuration variable in an application changes the location of the
install. However in this one case in nginx uninstall /srv/www is
hard coded as the directory prefix.
