### PR TITLE
Run bundle install with the --deployment flag

### DIFF
--- a/rails/libraries/rails_configuration.rb
+++ b/rails/libraries/rails_configuration.rb
@@ -37,8 +37,8 @@ module OpsWorks
     def self.bundle(app_name, app_config, app_root_path)
       if File.exists?("#{app_root_path}/Gemfile")
         Chef::Log.info("Gemfile detected. Running bundle install.")
-        Chef::Log.info("sudo su - #{app_config[:user]} -c 'cd #{app_root_path} && /usr/local/bin/bundle install --path #{app_config[:home]}/.bundler/#{app_name} --deployment --without #{app_config[:ignore_bundler_groups].join(' ')}'")
-        Chef::Log.info(OpsWorks::ShellOut.shellout("sudo su - #{app_config[:user]} -c 'cd #{app_root_path} && /usr/local/bin/bundle install --path #{app_config[:home]}/.bundler/#{app_name} --deployment --without #{app_config[:ignore_bundler_groups].join(' ')}' 2>&1"))
+        Chef::Log.info("sudo su - #{app_config[:user]} -c 'cd #{app_root_path} && /usr/local/bin/bundle install --path #{app_config[:home]}/.bundler/#{app_name} --deployment --without=#{app_config[:ignore_bundler_groups].join(' ')}'")
+        Chef::Log.info(OpsWorks::ShellOut.shellout("sudo su - #{app_config[:user]} -c 'cd #{app_root_path} && /usr/local/bin/bundle install --path #{app_config[:home]}/.bundler/#{app_name} --deployment --without=#{app_config[:ignore_bundler_groups].join(' ')}' 2>&1"))
       end
     end
   end

--- a/rails/libraries/rails_configuration.rb
+++ b/rails/libraries/rails_configuration.rb
@@ -37,8 +37,8 @@ module OpsWorks
     def self.bundle(app_name, app_config, app_root_path)
       if File.exists?("#{app_root_path}/Gemfile")
         Chef::Log.info("Gemfile detected. Running bundle install.")
-        Chef::Log.info("sudo su - #{app_config[:user]} -c 'cd #{app_root_path} && /usr/local/bin/bundle install --path #{app_config[:home]}/.bundler/#{app_name} --without=#{app_config[:ignore_bundler_groups].join(' ')}'")
-        Chef::Log.info(OpsWorks::ShellOut.shellout("sudo su - #{app_config[:user]} -c 'cd #{app_root_path} && /usr/local/bin/bundle install --path #{app_config[:home]}/.bundler/#{app_name} --without=#{app_config[:ignore_bundler_groups].join(' ')}' 2>&1"))
+        Chef::Log.info("sudo su - #{app_config[:user]} -c 'cd #{app_root_path} && /usr/local/bin/bundle install --path #{app_config[:home]}/.bundler/#{app_name} --deployment --without #{app_config[:ignore_bundler_groups].join(' ')}'")
+        Chef::Log.info(OpsWorks::ShellOut.shellout("sudo su - #{app_config[:user]} -c 'cd #{app_root_path} && /usr/local/bin/bundle install --path #{app_config[:home]}/.bundler/#{app_name} --deployment --without #{app_config[:ignore_bundler_groups].join(' ')}' 2>&1"))
       end
     end
   end


### PR DESCRIPTION
On the production, bundle install should be ran with the "--deployment" flag.

~~To exclude a group, it's done via `--without group1 group2` and not `--without=group1 group2`~~

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/aws/opsworks-cookbooks/158)

<!-- Reviewable:end -->
