### PR TITLE
Use correct node attributes for db integration

### DIFF
--- a/opsworks_java/recipes/context.rb
+++ b/opsworks_java/recipes/context.rb
@@ -20,8 +20,8 @@ node[:deploy].each do |application, deploy|
     group node['opsworks_java'][node['opsworks_java']['java_app_server']]['group']
     mode 0640
     backup false
-    only_if { node['opsworks_java']['datasources'][application] }
-    variables(:resource_name => node['opsworks_java']['datasources'][application], :application => application)
+    only_if { deploy['database'] }
+    variables(:resource_name => deploy['database']['database'], :application => application)
     notifies :restart, "service[#{node['opsworks_java']['java_app_server']}]"
   end
 end


### PR DESCRIPTION
Noticed that the wrong node attributes were being used to integrate datasources. Fixed it.
