### PR TITLE
[Chef 11.10] Don't define a restart command unless the current instance is in the "rails-app" layer

### DIFF
--- a/deploy/definitions/opsworks_deploy.rb
+++ b/deploy/definitions/opsworks_deploy.rb
@@ -76,7 +76,7 @@ define :opsworks_deploy do
       symlink_before_migrate( deploy[:symlink_before_migrate] )
       action deploy[:action]
 
-      if deploy[:application_type] == 'rails'
+      if deploy[:application_type] == 'rails' && node[:opsworks][:instance][:layers].include?('rails-app')
         restart_command "sleep #{deploy[:sleep_before_restart]} && #{node[:opsworks][:rails_stack][:restart_command]}"
       end
 


### PR DESCRIPTION
This pull request makes the `opsworks_deploy` resource not define a restart command unless it is running on a `rails-app` instance. This means that on instances that have a copy of the Rails app, but not running a web server (like a Sidekiq, Clockwork, etc. layer), it won't try to restart Unicorn/Passenger.

License: Public Domain. Do whatever you want with this PR, including relicensing under any other license.
