### PR TITLE
[Chef 11.10] Support auto-detecting Postgres databases and using the right adapter

### DIFF
--- a/rails/libraries/rails_configuration.rb
+++ b/rails/libraries/rails_configuration.rb
@@ -14,6 +14,9 @@ module OpsWorks
           adapter = if bundle_list.include?('mysql2')
             Chef::Log.info("Looks like #{app_name} uses mysql2 in its Gemfile")
             'mysql2'
+          elsif bundle_list.include?('pg')
+            Chef::Log.info("Looks like #{app_name} uses pg in its Gemfile; using postgresql adapter")
+            'postgresql'
           else
             Chef::Log.info("Gem mysql2 not found in the Gemfile of #{app_name}, defaulting to mysql")
             'mysql'


### PR DESCRIPTION
`RailsConfiguration.determine_database_adapter` defaults to the "mysql" adapter if it doesn't find mysql2 in the bundle. This PR adds support for checking for the "pg" gem, and if so, using the "postgresql" adapter.

License: Public Domain. Do anything you want with this PR, including relicensing.
