### PR TITLE
Add except option to running berkshelf to exclude groups of cookbooks

### DIFF
--- a/opsworks_berkshelf/attributes/default.rb
+++ b/opsworks_berkshelf/attributes/default.rb
@@ -21,3 +21,5 @@ default['opsworks_berkshelf']['pkg_release'] = '1'
 
 default['opsworks_berkshelf']['rubygems_options'] = ''
 default['opsworks_berkshelf']['debug'] = false
+
+default['opsworks_berkshelf']['ignore_groups'] = ['test', 'development']

--- a/opsworks_berkshelf/providers/runner.rb
+++ b/opsworks_berkshelf/providers/runner.rb
@@ -32,6 +32,7 @@ def berks_install_command
     "install --path #{Opsworks::InstanceAgent::Environment.berkshelf_cookbooks_path}"
   end
 
+  options += " --except=#{node['opsworks_berkshelf']['ignore_groups'].join(' ')}"
   options += ' --debug' if node['opsworks_berkshelf']['debug']
 
   "#{OpsWorks::Berkshelf.berkshelf_binary} #{options}"


### PR DESCRIPTION
Defaulting with excluding 'test' and 'development' like bundler.
