### PR TITLE
Quick Fixes for PHP Cookbook

### DIFF
--- a/php/recipes/configure.rb
+++ b/php/recipes/configure.rb
@@ -1,6 +1,6 @@
 node[:deploy].each do |application, deploy|
   if deploy[:application_type] != 'php'
-    Chef::Log.debug("Skipping deploy::php application #{application} as it is not an PHP app")
+    Chef::Log.debug("Skipping php::configure application #{application} as it is not an PHP app")
     next
   end
 

--- a/php/templates/default/opsworks.php.erb
+++ b/php/templates/default/opsworks.php.erb
@@ -23,8 +23,7 @@ class OpsWorksMemcached {
 }
 
 class OpsWorks {
-  public $db;
-  public $memcached;
+  public $db, $memcached, $stack_name;
   private $stack_map;
 
   public function __construct() {
@@ -42,4 +41,3 @@ class OpsWorks {
     return $this->stack_map[$layer];
   }
 }
-?>


### PR DESCRIPTION
- Remove php closing tag along with trailing whitespace which may cause premature output by certain PHP configurations.
- Declare $stack_name class variable
- Fix typo in php::configure debug message
