### PR TITLE
Quick Restart Unicorn regardless of Gemfile Changes. 

### DIFF
--- a/deploy/attributes/rails_stack.rb
+++ b/deploy/attributes/rails_stack.rb
@@ -25,7 +25,7 @@ when "nginx_unicorn"
   normal[:opsworks][:rails_stack][:recipe] = "unicorn::rails"
   normal[:opsworks][:rails_stack][:needs_reload] = true
   normal[:opsworks][:rails_stack][:service] = 'unicorn'
-  normal[:opsworks][:rails_stack][:restart_command] = '../../shared/scripts/unicorn clean-restart'
+  normal[:opsworks][:rails_stack][:restart_command] = '../../shared/scripts/unicorn restart'
 else
   raise "Unknown stack: #{node[:opsworks][:rails_stack][:name].inspect}"
 end

--- a/unicorn/templates/default/unicorn.service.erb
+++ b/unicorn/templates/default/unicorn.service.erb
@@ -25,17 +25,6 @@ def unicorn_running?
   end
 end
 
-def different_gemfile?
-  if File.exists?("#{ROOT_PATH}/current/Gemfile")
-    dir = Dir["#{ROOT_PATH}/releases/*"]
-    previous_release_path = dir.sort[dir.size-2]
-    if !previous_release_path.nil? && File.exists?("#{previous_release_path}/Gemfile")
-      return Digest::MD5.hexdigest(File.read("#{ROOT_PATH}/current/Gemfile")) != Digest::MD5.hexdigest(File.read("#{previous_release_path}/Gemfile"))
-    end
-  end
-  false
-end
-
 def start_unicorn
   if File.exists?("#{ROOT_PATH}/current/Gemfile")
     puts "OpsWorks: Gemfile detected - running Unicorn with bundle exec"
@@ -65,14 +54,8 @@ def restart_unicorn
 end
 
 def clean_restart
-  if different_gemfile?
-    puts "Found a previous version with a different Gemfile: Doing a stop & start"
-    stop_unicorn if unicorn_running?
-    start_unicorn
-  else
-    puts "No previous version with a different Gemfile found. Assuming a quick restart without re-loading gems is save"
-    restart_unicorn
-  end
+  stop_unicorn if unicorn_running?
+  start_unicorn
 end
 
 def status_unicorn


### PR DESCRIPTION
Unicorn will now always do a zero-downtime deployment even if the Gemfile has changed.

In `unicorn.conf.erb` the possibility of a changed Gemfile is already handled, so it is safe to do a quick restart.

The `clean_restart` function is left in place for anyone who needs it for a different context.
