### PR TITLE
Make CodeIgniter and expression engine works.

### DIFF
--- a/deploy/specs/php_spec.rb
+++ b/deploy/specs/php_spec.rb
@@ -12,7 +12,7 @@ describe_recipe 'deploy::php' do
     end
   end
 
-  ['log','config','system','pids','scripts','sockets'].each do |dir_name|
+  ['log','config','pids','scripts','sockets'].each do |dir_name|
     it "creates a directory #{dir_name} in the deployment directory" do
       node[:deploy].each do |application, deploy|
         if deploy[:application_type] == 'php'


### PR DESCRIPTION
As described here https://github.com/aws/opsworks-cookbooks/issues/153 it make no sense that opswork create those symlinks for a php project because it's a Ruby on Rails standard. At least, 'log' and 'config' can make sense, but 'system' create problems with the well-known php framework Codeigniter and it's CMS, ExpressionEngine.
