### PR TITLE
Remove hard-coded path for security certificates for Nginx

### DIFF
--- a/nginx/templates/default/site.erb
+++ b/nginx/templates/default/site.erb
@@ -34,10 +34,10 @@ server {
   access_log  <%= node[:nginx][:log_dir] %>/<%= @application[:domains].first %>-ssl.access.log;
   
   ssl on;
-  ssl_certificate /etc/nginx/ssl/<%= @application[:domains].first %>.crt;
-  ssl_certificate_key /etc/nginx/ssl/<%= @application[:domains].first %>.key;
+  ssl_certificate <%= node[:nginx][:dir] %>/ssl/<%= @application[:domains].first %>.crt;
+  ssl_certificate_key <%= node[:nginx][:dir] %>/ssl/<%= @application[:domains].first %>.key;
   <% if @application[:ssl_certificate_ca] -%>
-  ssl_client_certificate /etc/nginx/ssl/<%= @application[:domains].first %>.ca;
+  ssl_client_certificate <%= node[:nginx][:dir] %>/ssl/<%= @application[:domains].first %>.ca;
   <% end -%>
 
   location / {


### PR DESCRIPTION
The ssl certificates path that is entered in the nginx config is hard-coded currently and not based on path relative to the specified location of nginx configuration files using the 'dir' attribute (node[:nginx][:dir]).
