### PR TITLE
Implement "symlinks" deploy attribute consistant with documentation

### DIFF
--- a/deploy/attributes/deploy.rb
+++ b/deploy/attributes/deploy.rb
@@ -97,6 +97,7 @@ node[:deploy].each do |application, deploy|
   default[:deploy][application][:delete_cached_copy] = true
   default[:deploy][application][:create_dirs_before_symlink] = ['tmp', 'public', 'config']
   default[:deploy][application][:symlink_before_migrate] = {}
+  default[:deploy][application][:symlinks] = {"system" => "public/system", "pids" => "tmp/pids", "log" => "log"}
 
   default[:deploy][application][:environment] = {"RAILS_ENV" => deploy[:rails_env],
                                                  "RUBYOPT" => "",

--- a/deploy/definitions/opsworks_deploy.rb
+++ b/deploy/definitions/opsworks_deploy.rb
@@ -74,6 +74,7 @@ define :opsworks_deploy do
       environment deploy[:environment].to_hash
       create_dirs_before_symlink( deploy[:create_dirs_before_symlink] )
       symlink_before_migrate( deploy[:symlink_before_migrate] )
+      symlinks( deploy[:symlinks] )
       action deploy[:action]
 
       if deploy[:application_type] == 'rails' && node[:opsworks][:instance][:layers].include?('rails-app')


### PR DESCRIPTION
According to the [OpsWorks documentation](http://docs.aws.amazon.com/opsworks/latest/userguide/attributes-json-deploy.html#attributes-json-deploy-app-symlinks) there should be a "symlinks" attribute which gets passed to the chef deploy resource.

It can even be seen when running `opsworks-agent-cli get_json`, so it seems as though it should do something, however the deploy cookbook currently ignores the attribute.  This PR should fix it.

I have added a default consistent with the definition at:
https://github.com/opscode/chef/blob/469bed/lib/chef/resource/deploy.rb#L70
