### PR TITLE
Implement "purge_before_symlink" deploy attribute

### DIFF
--- a/deploy/attributes/deploy.rb
+++ b/deploy/attributes/deploy.rb
@@ -95,6 +95,7 @@ node[:deploy].each do |application, deploy|
   default[:deploy][application][:enable_submodules] = true
   default[:deploy][application][:shallow_clone] = false
   default[:deploy][application][:delete_cached_copy] = true
+  default[:deploy][application][:purge_before_symlink] = ['log', 'tmp/pids', 'public/system']
   default[:deploy][application][:create_dirs_before_symlink] = ['tmp', 'public', 'config']
   default[:deploy][application][:symlink_before_migrate] = {}
 

--- a/deploy/definitions/opsworks_deploy.rb
+++ b/deploy/definitions/opsworks_deploy.rb
@@ -72,6 +72,7 @@ define :opsworks_deploy do
       migrate deploy[:migrate]
       migration_command deploy[:migrate_command]
       environment deploy[:environment].to_hash
+      purge_before_symlink( deploy[:purge_before_symlink] )
       create_dirs_before_symlink( deploy[:create_dirs_before_symlink] )
       symlink_before_migrate( deploy[:symlink_before_migrate] )
       action deploy[:action]


### PR DESCRIPTION
Companion to PR #201.  Would be nice to have full control over `symlinks`, `symlink_before_migrate`, `create_dirs_before_symlink`, and `purge_before_symlink` when making custom deploy recipes.

Also would be nice to override these defaults in apps where we don't need the `logs`, `pids`, `config`, and `system` symlinks created for our deployments.

I have added a default for `purge_before_symlink` consistent with the definition at:
https://github.com/opscode/chef/blob/469bed/lib/chef/resource/deploy.rb#L67

I agree to supply this patch under your Apache 2.0 license.
