### PR TITLE
Remove bashism from monit nodejs template

### DIFF
--- a/opsworks_nodejs/templates/default/node_web_app.monitrc.erb
+++ b/opsworks_nodejs/templates/default/node_web_app.monitrc.erb
@@ -1,5 +1,5 @@
 check host node_web_app_<%= @application_name %> with address 127.0.0.1
-  start program = "/bin/sh -c 'cd <%= @deploy[:deploy_to] %>/current ; source <%= @deploy[:deploy_to] %>/shared/app.env ; /usr/bin/env PORT=<%= @deploy[:nodejs][:port] %> NODE_PATH=<%= @deploy[:deploy_to] %>/current/node_modules:<%= @deploy[:deploy_to] %>/current /usr/local/bin/node <%= @monitored_script %>'"
+  start program = "/bin/sh -c 'cd <%= @deploy[:deploy_to] %>/current ; . <%= @deploy[:deploy_to] %>/shared/app.env ; /usr/bin/env PORT=<%= @deploy[:nodejs][:port] %> NODE_PATH=<%= @deploy[:deploy_to] %>/current/node_modules:<%= @deploy[:deploy_to] %>/current /usr/local/bin/node <%= @monitored_script %>'"
   stop program = "/usr/bin/pkill -f 'node <%= @monitored_script %>'"
   <% if @deploy[:ssl_support] -%>
   if failed port <%= @deploy[:nodejs][:port] %> type TCPSSL protocol HTTP


### PR DESCRIPTION
https://github.com/aws/opsworks-cookbooks/blob/release-chef-11.10/opsworks_nodejs/templates/default/node_web_app.monitrc.erb#L2 - this uses `source` to set up the environment but actually `dash` is a default shell in Ubuntu and it does not support the command: https://wiki.ubuntu.com/DashAsBinSh#source
