### PR TITLE
Remove unneed inspect

### DIFF
--- a/rails/templates/default/database.yml.erb
+++ b/rails/templates/default/database.yml.erb
@@ -8,10 +8,10 @@
   password: <%= @database[:password].to_s.inspect %>
   reconnect: <%= @database[:reconnect] ? 'true' : 'false' %>
 <% if @database[:pool] -%>
-  pool: <%= @database[:pool].to_i.inspect %>
+  pool: <%= @database[:pool].to_i %>
 <% end -%>
 <% if @database[:port] -%>
-  port: <%= @database[:port].to_i.inspect %>
+  port: <%= @database[:port].to_i %>
 <% end -%>
 
 <% end %>


### PR DESCRIPTION
I don't think `to_i.inspect` is necessary in this code. Here is my investigation.

```
irb>  puts "1".to_i.inspect
1
=> nil
irb>  puts "1".to_i
1
=> nil
```

The result is exactly same. If it should be just a String, I guess `to_i.to_s` is enough?
