### PR TITLE
Rails database.yml, don't specify database key if it's not provided

### DIFF
--- a/rails/templates/default/database.yml.erb
+++ b/rails/templates/default/database.yml.erb
@@ -1,7 +1,9 @@
 <% (['development', 'production'] + [@environment]).uniq.each do |env| -%>
 <%= env %>:
   adapter: <%= @database[:adapter].to_s.inspect %>
+<% if @database[:database] -%>
   database: <%= @database[:database].to_s.inspect %>
+<% end -%>
   encoding: <%= (@database[:encoding] || 'utf8').to_s.inspect %>
   host: <%= (@database[:host] || 'localhost').to_s.inspect %>
   username: <%= @database[:username].to_s.inspect %>


### PR DESCRIPTION
I'm working with an external MS Sql server and since I've only to use stored procedures I've to connect to it without specifying a database since I haven't any access to any database.
