### PR TITLE
Allow usage of SPDY and gzip json in NGINX

### DIFF
--- a/nginx/attributes/nginx.rb
+++ b/nginx/attributes/nginx.rb
@@ -51,6 +51,7 @@ default[:nginx][:gzip_types] = ["application/x-javascript",
                                 "application/xhtml+xml",
                                 "application/xml",
                                 "application/xml+rss",
+                                "application/json",
                                 "text/css",
                                 "text/javascript",
                                 "text/plain",
@@ -66,5 +67,7 @@ default[:nginx][:server_names_hash_bucket_size] = 64
 
 default[:nginx][:proxy_read_timeout] = 60
 default[:nginx][:proxy_send_timeout] = 60
+
+default[:nginx][:enable_spdy] = false
 
 include_attribute "nginx::customize"

--- a/nginx/templates/default/site.erb
+++ b/nginx/templates/default/site.erb
@@ -29,7 +29,7 @@ server {
 
 <% if @application[:ssl_support] %>
 server {
-  listen   443;
+  listen   443 ssl <%= "spdy" if node[:nginx][:enable_spdy] %>;
   server_name  <%= @application[:domains].join(" ") %> <%= node[:hostname] %>;
   access_log  <%= node[:nginx][:log_dir] %>/<%= @application[:domains].first %>-ssl.access.log;
   

--- a/unicorn/templates/default/nginx_unicorn_web_app.erb
+++ b/unicorn/templates/default/nginx_unicorn_web_app.erb
@@ -61,7 +61,7 @@ server {
 
 <% if @application[:ssl_support] %>
 server {
-  listen   443;
+  listen   443 ssl <%= "spdy" if node[:nginx][:enable_spdy] %>;
   server_name <%= @application[:domains].join(" ") %> <%= node[:hostname] %>;
   access_log <%= node[:nginx][:log_dir] %>/<%= @application[:domains].first %>-ssl.access.log;
   

--- a/unicorn/templates/default/nginx_unicorn_web_app.erb
+++ b/unicorn/templates/default/nginx_unicorn_web_app.erb
@@ -14,7 +14,7 @@ server {
   access_log <%= node[:nginx][:log_dir] %>/<%= @application[:domains].first %>.access.log;
   <%end %>
 
-  keepalive_timeout 5;
+  keepalive_timeout <%= node[:nginx][:keepalive_timeout] %>;
 
   root <%= @application[:absolute_document_root] %>;
 
@@ -72,7 +72,7 @@ server {
   ssl_client_certificate /etc/nginx/ssl/<%= @application[:domains].first %>.ca;
   <% end -%>
 
-  keepalive_timeout 5;
+  keepalive_timeout <%= node[:nginx][:keepalive_timeout] %>;
 
   root <%= @application[:absolute_document_root] %>;
 


### PR DESCRIPTION
This pull request provides the following features and fixes to NGINX and Unicorn cookbooks:
- Allow users to enable spdy in Nginx for HTTPS enabled sites. Almost all modern distributions ships an nginx version with SPDY enabled.
- Enables gzip for json requests. This is useful for json api services.
- Fix missing node[:nginx][:keepalive_timeout] on the unicorn nginx templates

To check if nginx has spdy enabled, run this command:

```
nginx -V 2>&1 | grep "spdy"
```

Then enable spdy on the stack json

``` json
"nginx": {
  "enable_spdy": true
}
```
