### PR TITLE
create extract method from defined extract script in filesystem.

### DIFF
--- a/scm_helper/libraries/archive.rb
+++ b/scm_helper/libraries/archive.rb
@@ -1,4 +1,5 @@
 require 'tmpdir'
+require 'fileutils'
 
 module OpsWorks
   module SCM
@@ -22,9 +23,7 @@ module OpsWorks
           source archive_url
         end
 
-        execute 'extract files' do
-          command "#{node[:opsworks_agent][:current_dir]}/bin/extract #{tmpdir}/archive"
-        end
+        extract_archive("#{tmpdir}/archive")
 
         execute 'create git repository' do
           cwd "#{tmpdir}/archive.d"

--- a/scm_helper/libraries/package.rb
+++ b/scm_helper/libraries/package.rb
@@ -29,6 +29,59 @@ module OpsWorks
         end
       end
 
+      def extract_archive(source)
+        ruby_block "extract files" do
+          block do
+            archive = source
+            directory = source + '.d'
+            format = `file #{archive}`.chomp
+            if format.match /bzip2 compressed data/
+              FileUtils.mkdir(directory)
+              puts `tar xfj #{archive} -C #{directory}`
+            elsif format.match /gzip compressed data/
+              FileUtils.mkdir(directory)
+              puts `tar xfz #{archive} -C #{directory}`
+            elsif format.match /Zip archive data/
+              puts `unzip -d #{directory} #{archive}`
+            elsif format.match(/XML/) && (file_content = File.read(archive)).match(/AWS (authentication|access)/i)
+              puts 'The downloaded file looks like an error message wrapped in XML. Check your credentials.'
+              puts file_content
+              exit 1
+            elsif format.match(/XML/) && (file_content = File.read(archive)).match(/internal error/i)
+              puts 'The download from S3 failed. See below for S3 error:'
+              puts file_content
+              exit 1
+            elsif format.match(/XML/) && (file_content = File.read(archive)).match(/SignatureDoesNotMatch/i)
+              puts 'The download from S3 failed. See below for S3 error. If this is a public-read S3 item, please try switching to the HTTP type'
+              puts file_content
+              exit 1
+            elsif format.match(/XML/) && (file_content = File.read(archive)).match(/PermanentRedirect/i)
+              puts 'The download from S3 failed. See below for S3 error. The bucket URL is not correct, please use the canocial version named below:'
+              puts file_content
+              exit 1
+            elsif format.match(/XML/) && (file_content = File.read(archive)).match(/\<Error\>/i)
+              puts 'The download from S3 failed. See below for S3 error:'
+              puts file_content
+              exit 1
+            else
+              puts "unhandled archive format '#{format}' - not extracting"
+              FileUtils.mkdir(directory)
+              FileUtils.mv(archive, directory)
+            end
+            FileUtils.rm_rf "#{directory}/__MACOSX"
+            archive_content = Dir[directory + '/*']
+            if archive_content.size == 1 && ::File.directory?(archive_content.first)
+              Dir[archive_content.first + '/{*,.*}'].each do |child|
+                unless ['.', '..'].include?(File.basename(child))
+                  FileUtils.mv(child, directory)
+                end
+              end
+              FileUtils.rmdir(archive_content.first)
+            end
+          end
+        end
+
+      end      
     end
   end
 end

--- a/scm_helper/libraries/s3.rb
+++ b/scm_helper/libraries/s3.rb
@@ -20,9 +20,7 @@ module OpsWorks
           command "#{node[:opsworks_agent][:current_dir]}/bin/s3curl.pl --id opsworks -- -o #{tmpdir}/archive #{scm_options[:repository]}"
         end
 
-        execute 'extract files' do
-          command "#{node[:opsworks_agent][:current_dir]}/bin/extract #{tmpdir}/archive"
-        end
+        extract_archive("#{tmpdir}/archive")
 
         execute 'create git repository' do
           cwd "#{tmpdir}/archive.d"


### PR DESCRIPTION
Previously the extract method execute a script located at filesystem (specifically, script at `"#{node[:opsworks_agent][:current_dir]}/bin/extract #{tmpdir}/archive`). The script may not exists in local environment. This way, we can use the script in environment where `opsworks_agent` doesn't exists.
