### PR TITLE
Bug in error handling code of AWS Flow initrc script

### DIFF
--- a/opsworks_aws_flow_ruby/templates/default/aws_flow_ruby_app.initrc.erb
+++ b/opsworks_aws_flow_ruby/templates/default/aws_flow_ruby_app.initrc.erb
@@ -47,7 +47,8 @@ start() {
     return 0
   else
     echo "$name failed to start"
-    cat /var/log/$name.{log,err}
+    cat /var/log/$name.log
+    cat /var/log/$name.err
     return 1
   fi
 }


### PR DESCRIPTION
Any error in starting the workers results in the following being written to the log:

```
Mixlib::ShellOut::ShellCommandFailed
------------------------------------
Expected process to exit with [0], but received '1'
---- Begin output of /srv/www/workers/current/runner.initrc restart ----
STDOUT: workers failed to start
STDERR: cat: /var/log/workers.{log,err}: No such file or directory
---- End output of /srv/www/workers/current/runner.initrc restart ----
Ran /srv/www/workers/current/runner.initrc restart returned 1
```

Fixes #223
