### PR TITLE
Add recursive log dir creation facility for nginx

### DIFF
--- a/nginx/recipes/default.rb
+++ b/nginx/recipes/default.rb
@@ -30,6 +30,7 @@ directory node[:nginx][:log_dir] do
   mode 0755
   owner node[:nginx][:user]
   action :create
+  recursive true
 end
 
 %w{sites-available sites-enabled conf.d}.each do |dir|


### PR DESCRIPTION
Setup fails if user wants Nginx logs to be in a different directory structure. For example, if it is set to /mount_point/var/log/nginx, if var & log aren't created recursively, it fails. 
This fix helps with the above by adding recursive creation of directories.
