### PR TITLE
Allow nginx to gzip more types

### DIFF
--- a/nginx/attributes/nginx.rb
+++ b/nginx/attributes/nginx.rb
@@ -47,13 +47,23 @@ default[:nginx][:gzip_disable] = "MSIE [1-6].(?!.*SV1)"
 default[:nginx][:gzip_http_version] = "1.0"
 default[:nginx][:gzip_comp_level] = "2"
 default[:nginx][:gzip_proxied] = "any"
-default[:nginx][:gzip_types] = ["application/x-javascript",
+default[:nginx][:gzip_types] = ["application/atom+xml",
+                                "application/javascript",
+                                "application/json",
+                                "application/rss+xml",
+                                "application/x-font-ttf",
+                                "application/x-javascript",
+                                "application/x-web-app-manifest+json",
                                 "application/xhtml+xml",
                                 "application/xml",
                                 "application/xml+rss",
+                                "font/opentype",
+                                "image/svg+xml",
+                                "image/x-icon",
                                 "text/css",
                                 "text/javascript",
                                 "text/plain",
+                                "text/x-component",
                                 "text/xml"]
 # NGinx will compress "text/html" by default
 


### PR DESCRIPTION
It would be quite important for servers in production to compress JSON / JavaScript and other common mime types.

The mime type list is copied from H5BP's Nginx Server Configs project:
https://github.com/h5bp/server-configs-nginx/blob/master/nginx.conf#L93
