### PR TITLE
SSL improvements

### DIFF
--- a/nginx/attributes/customize.rb
+++ b/nginx/attributes/customize.rb
@@ -15,3 +15,7 @@
 # The default ssl_protocols will be used if not set.
 # See: http://nginx.org/en/docs/http/configuring_https_servers.html
 #normal[:nginx][:ssl_protocols] = 'TLSv1 TLSv1.1 TLSv1.2'
+
+# The following allows ssl to be enforced by all connections by
+# redirecting all trafic coming to port 80 to port 443
+#normal[:nginx][:force_ssl] = true

--- a/nginx/attributes/customize.rb
+++ b/nginx/attributes/customize.rb
@@ -10,3 +10,8 @@
 #
 #normal[:nginx][:gzip] = 'off'
 #normal[:nginx][:gzip_static] = 'off'
+
+# The following allows specification of the ssl_protocols
+# The default ssl_protocols will be used if not set.
+# See: http://nginx.org/en/docs/http/configuring_https_servers.html
+#normal[:nginx][:ssl_protocols] = 'TLSv1 TLSv1.1 TLSv1.2'

--- a/nginx/attributes/customize.rb
+++ b/nginx/attributes/customize.rb
@@ -15,6 +15,8 @@
 # The default ssl_protocols will be used if not set.
 # See: http://nginx.org/en/docs/http/configuring_https_servers.html
 #normal[:nginx][:ssl_protocols] = 'TLSv1 TLSv1.1 TLSv1.2'
+# arrays are also supported
+#normal[:nginx][:ssl_protocols] = ['TLSv1', 'TLSv1.1', 'TLSv1.2']
 
 # The following allows ssl to be enforced by all connections by
 # redirecting all trafic coming to port 80 to port 443

--- a/nginx/attributes/nginx.rb
+++ b/nginx/attributes/nginx.rb
@@ -67,4 +67,7 @@ default[:nginx][:server_names_hash_bucket_size] = 64
 default[:nginx][:proxy_read_timeout] = 60
 default[:nginx][:proxy_send_timeout] = 60
 
+# SSL
+default[:nginx][:ssl_protocols] = nil # rely on default provided by nginx
+
 include_attribute "nginx::customize"

--- a/nginx/attributes/nginx.rb
+++ b/nginx/attributes/nginx.rb
@@ -69,5 +69,6 @@ default[:nginx][:proxy_send_timeout] = 60
 
 # SSL
 default[:nginx][:ssl_protocols] = nil # rely on default provided by nginx
+default[:nginx][:force_ssl] = false # Force HTTP to redirect to HTTPS
 
 include_attribute "nginx::customize"

--- a/nginx/templates/default/site.erb
+++ b/nginx/templates/default/site.erb
@@ -3,28 +3,32 @@ server {
   server_name  <%= @application[:domains].join(" ") %> <%= node[:hostname] %>;
   access_log  <%= node[:nginx][:log_dir] %>/<%= @application[:domains].first %>.access.log;
 
+  <% if node[:nginx][:force_ssl] -%>
+  return 301 https://$server_name$request_uri?;
+  <% end -%>
+
   location / {
     root   <%= @application[:absolute_document_root] %>;
     index  index.html index.htm index.php;
   }
-  
+
   # Block all svn access
   if ($request_uri ~* ^.*\.svn.*$) {
      return 404;
   }
-  
+
   # Block all git access
   if ($request_uri ~* ^.*\.git.*$) {
      return 404;
   }
-  
+
   location /nginx_status {
     stub_status on;
     access_log off;
     allow 127.0.0.1;
     deny all;
   }
-  
+
 }
 
 <% if @application[:ssl_support] %>
@@ -32,7 +36,7 @@ server {
   listen   443;
   server_name  <%= @application[:domains].join(" ") %> <%= node[:hostname] %>;
   access_log  <%= node[:nginx][:log_dir] %>/<%= @application[:domains].first %>-ssl.access.log;
-  
+
   ssl on;
   ssl_certificate <%= node[:nginx][:dir] %>/ssl/<%= @application[:domains].first %>.crt;
   ssl_certificate_key <%= node[:nginx][:dir] %>/ssl/<%= @application[:domains].first %>.key;
@@ -48,12 +52,12 @@ server {
     root   <%= @application[:absolute_document_root] %>;
     index  index.html index.htm index.php;
   }
-  
+
   # Block all svn access
   if ($request_uri ~* ^.*\.svn.*$) {
      return 404;
   }
-  
+
   # Block all git access
   if ($request_uri ~* ^.*\.git.*$) {
      return 404;

--- a/nginx/templates/default/site.erb
+++ b/nginx/templates/default/site.erb
@@ -40,6 +40,10 @@ server {
   ssl_client_certificate <%= node[:nginx][:dir] %>/ssl/<%= @application[:domains].first %>.ca;
   <% end -%>
 
+  <% unless node[:nginx][:ssl_protocols].nil? -%>
+  ssl_protocols <%= node[:nginx][:ssl_protocols] %>
+  <% end -%>
+
   location / {
     root   <%= @application[:absolute_document_root] %>;
     index  index.html index.htm index.php;

--- a/nginx/templates/default/site.erb
+++ b/nginx/templates/default/site.erb
@@ -45,7 +45,11 @@ server {
   <% end -%>
 
   <% unless node[:nginx][:ssl_protocols].nil? -%>
-  ssl_protocols <%= node[:nginx][:ssl_protocols] %>
+    <% if node[:nginx][:ssl_protocols].respond_to?(:join) -%>
+      ssl_protocols <%= node[:nginx][:ssl_protocols].join(' ') %>
+    <% elsif -%>
+      ssl_protocols <%= node[:nginx][:ssl_protocols] %>
+    <% end -%>
   <% end -%>
 
   location / {


### PR DESCRIPTION
Keeps using the default value for `ssl_protocols` from nginx if an override is not specified explicitly.
Adds a property called `force_ssl` which when set to true causes traffic to HTTP to be redirected to HTTPS
