### PR TITLE
Use "httpd24" package instead of "httpd"

### DIFF
--- a/apache2/recipes/default.rb
+++ b/apache2/recipes/default.rb
@@ -20,7 +20,7 @@
 package 'apache2' do
   case node[:platform_family]
   when 'rhel'
-    package_name 'httpd'
+    package_name 'httpd24'
   when 'debian'
     package_name 'apache2'
   end
@@ -31,7 +31,7 @@ include_recipe 'apache2::service'
 
 service 'apache2' do
   service_name value_for_platform_family(
-    'rhel' => 'httpd',
+    'rhel' => 'httpd24',
     'debian' => 'apache2'
   )
   action :enable

--- a/apache2/recipes/mod_fcgid.rb
+++ b/apache2/recipes/mod_fcgid.rb
@@ -30,7 +30,7 @@ elsif platform?('centos', 'redhat', 'fedora', 'amazon')
   end
 elsif platform?('suse')
   apache_lib_path = RUBY_PLATFORM.match(/64/) ? '/usr/lib64/httpd' : '/usr/lib/httpd'
-  package 'httpd-devel'
+  package 'httpd24-devel'
   bash 'install-fcgid' do
     code <<-EOH
 (cd /tmp; wget http://superb-east.dl.sourceforge.net/sourceforge/mod-fcgid/mod_fcgid.2.2.tgz)

--- a/apache2/recipes/service.rb
+++ b/apache2/recipes/service.rb
@@ -1,6 +1,6 @@
 service 'apache2' do
   service_name value_for_platform_family(
-    'rhel' => 'httpd',
+    'rhel' => 'httpd24',
     'debian' => 'apache2'
   )
 
@@ -9,7 +9,7 @@ service 'apache2' do
   # during the initial bootstrap.
   ['restart','reload'].each do |srv_cmd|
     send("#{srv_cmd}_command", value_for_platform_family(
-        'rhel' => "sleep 1 && /sbin/service httpd #{srv_cmd} && sleep 1",
+        'rhel' => "sleep 1 && /sbin/service httpd24 #{srv_cmd} && sleep 1",
         'debian' => "sleep 1 && /etc/init.d/apache2 #{srv_cmd} && sleep 1"
       )
     )

--- a/apache2/specs/default_spec.rb
+++ b/apache2/specs/default_spec.rb
@@ -22,7 +22,7 @@ describe_recipe 'apache2::default' do
       when 'debian'
         package('apache2').must_be_installed
       when 'rhel'
-        package('httpd').must_be_installed
+        package('httpd24').must_be_installed
       else
         fail_test "Your OS (#{node[:platform]}) is not supported."
       end
@@ -59,8 +59,8 @@ describe_recipe 'apache2::default' do
         service('apache2').must_be_enabled
         service('apache2').must_be_running
       when 'rhel'
-        service('httpd').must_be_enabled
-        service('httpd').must_be_running
+        service('httpd24').must_be_enabled
+        service('httpd24').must_be_running
       else
         fail_test "Your OS (#{node[:platform]}) is not supported."
       end

--- a/apache2/specs/stop_spec.rb
+++ b/apache2/specs/stop_spec.rb
@@ -7,7 +7,7 @@ describe_recipe 'apache2::stop' do
   it 'stops apache2' do
     case node[:platform_family]
     when 'rhel'
-      service('httpd').wont_be_running
+      service('httpd24').wont_be_running
     when 'debian'
       service('apache2').wont_be_running
     end

--- a/apache2/specs/uninstall_spec.rb
+++ b/apache2/specs/uninstall_spec.rb
@@ -9,7 +9,7 @@ describe_recipe 'apache2::uninstall' do
     when 'debian'
       service('apache2').wont_be_running
     when 'rhel'
-      service('httpd').wont_be_running
+      service('httpd24').wont_be_running
     else
       # Fail test if we don't have a supported OS.
       assert_equal(3, nil)
@@ -21,7 +21,7 @@ describe_recipe 'apache2::uninstall' do
     when 'debian'
       package('apache2').wont_be_installed
     when 'rhel'
-      package('httpd').wont_be_installed
+      package('httpd24').wont_be_installed
     else
       # Fail test if we don't have a supported OS.
       assert_equal(3, nil)

--- a/opsworks_ganglia/specs/configure-server_spec.rb
+++ b/opsworks_ganglia/specs/configure-server_spec.rb
@@ -52,7 +52,7 @@ describe_recipe 'opsworks_ganglia::configure-server' do
     when "debian"
      service('apache2').must_be_running
     when "rhel"
-      service('httpd').must_be_running
+      service('httpd24').must_be_running
     end
   end
 

--- a/passenger_apache2/recipes/default.rb
+++ b/passenger_apache2/recipes/default.rb
@@ -29,7 +29,7 @@ include_recipe 'apache2::service'
 
 case node[:platform]
 when "centos","redhat","amazon"
-  package "httpd-devel"
+  package "httpd24-devel"
   if node['platform_version'].to_f < 6.0
     package 'curl-devel'
   else

--- a/passenger_apache2/specs/default_spec.rb
+++ b/passenger_apache2/specs/default_spec.rb
@@ -16,7 +16,7 @@ describe_recipe 'passenger_apache2::default' do
       skip unless node[:packages][:dist_only]
       case node[:platform]
       when 'centos','redhat','amazon'
-        package('httpd-devel').must_be_installed
+        package('httpd24-devel').must_be_installed
         if node['platform_version'].to_f < 6.0
           package('curl-devel').must_be_installed
         else


### PR DESCRIPTION
The PHP 5.3 (package name: "php"), that installed by default works just fine with Apache 2.2 (package name: "httpd"). However when I try to install PHP 5.4 instead, then I've got yum conflicts.

To solve that I propose using "httpd24" package, that works pretty fine with PHP 5.4 version.

Since there are no contribution manual present in the repo I don't know how to run tests that verify that all works fine.
