### PR TITLE
Use "php54" package instead of "php"

### DIFF
--- a/apache2/recipes/mod_php5.rb
+++ b/apache2/recipes/mod_php5.rb
@@ -23,7 +23,7 @@ when 'debian'
     action :install
   end
 when 'rhel'
-  package 'php' do
+  package 'php54' do
     action :install
     notifies :run, "execute[generate-module-list]", :immediately
     not_if 'which php'

--- a/apache2/specs/mod_php5_spec.rb
+++ b/apache2/specs/mod_php5_spec.rb
@@ -18,7 +18,7 @@ describe_recipe 'apache2::mod_php5' do
     when 'debian'
       package('libapache2-mod-php5').must_be_installed
     when 'rhel'
-      package('php').must_be_installed
+      package('php54').must_be_installed
     end
   end
 

--- a/mod_php5_apache2/attributes/default.rb
+++ b/mod_php5_apache2/attributes/default.rb
@@ -38,15 +38,15 @@ when 'debian'
   ]
 when 'rhel'
   packages = [
-    'php-xml',
-    'php-common',
-    'php-xmlrpc',
-    'php-devel',
-    'php-gd',
-    'php-cli',
+    'php54-xml',
+    'php54-common',
+    'php54-xmlrpc',
+    'php54-devel',
+    'php54-gd',
+    'php54-cli',
     'php-pear-Auth-SASL',
-    'php-mcrypt',
-    'php-pecl-memcache',
+    'php54-mcrypt',
+    'php54-pecl-memcache',
     'php-pear',
     'php-pear-XML-Parser',
     'php-pear-Mail-Mime',

--- a/mod_php5_apache2/recipes/mysql_adapter.rb
+++ b/mod_php5_apache2/recipes/mysql_adapter.rb
@@ -1,6 +1,6 @@
 package 'php-mysql' do
   package_name value_for_platform_family(
-    'rhel' => 'php-mysql',
+    'rhel' => 'php54-mysql',
     'debian' => 'php5-mysql'
   )
 end

--- a/mod_php5_apache2/recipes/postgresql_adapter.rb
+++ b/mod_php5_apache2/recipes/postgresql_adapter.rb
@@ -1,6 +1,6 @@
 package 'php-pgsql' do
   package_name value_for_platform_family(
-    'rhel' => 'php-pgsql',
+    'rhel' => 'php54-pgsql',
     'debian' => 'php5-pgsql'
   )
 end

--- a/mod_php5_apache2/specs/default_spec.rb
+++ b/mod_php5_apache2/specs/default_spec.rb
@@ -27,15 +27,15 @@ describe_recipe "mod_php5_apache2::default" do
                 ]
               when "rhel"
                 [
-                  "php-xml",
-                  "php-common",
-                  "php-xmlrpc",
-                  "php-devel",
-                  "php-gd",
-                  "php-cli",
+                  "php54-xml",
+                  "php54-common",
+                  "php54-xmlrpc",
+                  "php54-devel",
+                  "php54-gd",
+                  "php54-cli",
                   "php-pear-Auth-SASL",
-                  "php-mcrypt",
-                  "php-pecl-memcache",
+                  "php54-mcrypt",
+                  "php54-pecl-memcache",
                   "php-pear",
                   "php-pear-XML-Parser",
                   "php-pear-Mail-Mime",
@@ -52,14 +52,14 @@ describe_recipe "mod_php5_apache2::default" do
         when "debian"
           packages << "php5-mysql"
         when "rhel"
-          packages << "php-mysql"
+          packages << "php54-mysql"
         end
       when "postgresql"
         case node[:platform_family]
         when "debian"
           packages << "php5-pgsql"
         when "rhel"
-          packages << "php-pgsql"
+          packages << "php54-pgsql"
         end
       end
     end


### PR DESCRIPTION
Will use PHP 5.4 instead of PHP 5.3 on RHEL repo. Ideally I want make PHP version suffix (e.g. "54", "55", "") configurable somewhere centrally, but I don't know how to do it.
