### PR TITLE
Make package name in "apache2" cookbook configurable

### DIFF
--- a/apache2/attributes/apache.rb
+++ b/apache2/attributes/apache.rb
@@ -33,8 +33,11 @@
 # See also: http://docs.aws.amazon.com/opsworks/latest/userguide/customizing.html
 ###
 
+default[:apache][:devel_package] = 'httpd-devel'
+
 case node[:platform_family]
 when 'rhel'
+  default[:apache][:package]       = 'httpd'
   default[:apache][:dir]           = '/etc/httpd'
   default[:apache][:log_dir]       = '/var/log/httpd'
   default[:apache][:user]          = 'apache'
@@ -51,6 +54,7 @@ when 'rhel'
   default[:apache][:libexecdir]    = "#{node[:apache][:lib_dir]}/modules"
   default[:apache][:document_root] = '/var/www/html'
 when 'debian'
+  default[:apache][:package]       = 'apache2'
   default[:apache][:dir]           = '/etc/apache2'
   default[:apache][:log_dir]       = '/var/log/apache2'
   default[:apache][:user]          = 'www-data'

--- a/apache2/recipes/default.rb
+++ b/apache2/recipes/default.rb
@@ -18,12 +18,7 @@
 #
 
 package 'apache2' do
-  case node[:platform_family]
-  when 'rhel'
-    package_name 'httpd'
-  when 'debian'
-    package_name 'apache2'
-  end
+  package_name node[:apache][:package]
   action :install
 end
 

--- a/apache2/recipes/mod_fcgid.rb
+++ b/apache2/recipes/mod_fcgid.rb
@@ -30,7 +30,7 @@ elsif platform?('centos', 'redhat', 'fedora', 'amazon')
   end
 elsif platform?('suse')
   apache_lib_path = RUBY_PLATFORM.match(/64/) ? '/usr/lib64/httpd' : '/usr/lib/httpd'
-  package 'httpd-devel'
+  package node[:apache][:devel_package]
   bash 'install-fcgid' do
     code <<-EOH
 (cd /tmp; wget http://superb-east.dl.sourceforge.net/sourceforge/mod-fcgid/mod_fcgid.2.2.tgz)

--- a/apache2/specs/default_spec.rb
+++ b/apache2/specs/default_spec.rb
@@ -18,14 +18,7 @@ describe_recipe 'apache2::default' do
 
   describe 'packages' do
     it 'installs the apache2 package' do
-      case node[:platform_family]
-      when 'debian'
-        package('apache2').must_be_installed
-      when 'rhel'
-        package('httpd').must_be_installed
-      else
-        fail_test "Your OS (#{node[:platform]}) is not supported."
-      end
+      package(node[:apache][:package]).must_be_installed
     end
   end
 

--- a/passenger_apache2/recipes/default.rb
+++ b/passenger_apache2/recipes/default.rb
@@ -29,7 +29,7 @@ include_recipe 'apache2::service'
 
 case node[:platform]
 when "centos","redhat","amazon"
-  package "httpd-devel"
+  package node[:apache][:devel_package]
   if node['platform_version'].to_f < 6.0
     package 'curl-devel'
   else

--- a/passenger_apache2/specs/default_spec.rb
+++ b/passenger_apache2/specs/default_spec.rb
@@ -16,7 +16,7 @@ describe_recipe 'passenger_apache2::default' do
       skip unless node[:packages][:dist_only]
       case node[:platform]
       when 'centos','redhat','amazon'
-        package('httpd-devel').must_be_installed
+        package(node[:apache][:devel_package]).must_be_installed
         if node['platform_version'].to_f < 6.0
           package('curl-devel').must_be_installed
         else


### PR DESCRIPTION
The PHP 5.3 (package name: "php"), that installed by default works just fine with Apache 2.2 (package name: "httpd"). However when I try to install PHP 5.4 instead, then I've got yum conflicts.

To solve that I propose using "httpd24" package, that works pretty fine with PHP 5.4 version.

Since there are no contribution manual present in the repo I don't know how to run tests that verify that all works fine.

I suppose the "apache2" cookbook originated from https://github.com/viverae-cookbooks/apache2 and I did this:
1. added new attribute `default[:apache][:package]` - with `httpd` value (for RedHat and relatives), `apache2` (for Debian and relatives)
2. add new attribute `default[:apache][:devel_package]` - with `httpd-devel` value
