### PR TITLE
Adding a list of attibutes to be used during checkout of custom recipes.

### DIFF
--- a/opsworks_custom_cookbooks/attributes/default.rb
+++ b/opsworks_custom_cookbooks/attributes/default.rb
@@ -33,6 +33,7 @@ default[:opsworks_custom_cookbooks][:scm][:repository] = nil
 
 default[:opsworks_custom_cookbooks][:scm][:revision] = 'HEAD'
 default[:opsworks_custom_cookbooks][:enable_submodules] = true
+default[:opsworks_custom_cookbooks][:scm][:arguments] = '--no-auth-cache'
 
 default[:opsworks_custom_cookbooks][:gem_binary] = '/opt/aws/opsworks/local/bin/gem'
 default[:opsworks_custom_cookbooks][:gem_uninstall_options] = '--force --executables'

--- a/opsworks_custom_cookbooks/recipes/checkout.rb
+++ b/opsworks_custom_cookbooks/recipes/checkout.rb
@@ -45,6 +45,7 @@ when 'svn'
   subversion "Download Custom Cookbooks" do
     svn_username node[:opsworks_custom_cookbooks][:scm][:user]
     svn_password node[:opsworks_custom_cookbooks][:scm][:password]
+    svn_arguments node[:opsworks_custom_cookbooks][:scm][:arguments]
 
     user node[:opsworks_custom_cookbooks][:user]
     group node[:opsworks_custom_cookbooks][:group]


### PR DESCRIPTION
It would be nice if AWS OpsWorks allowed for custom attributes to be set with the subversion provider. This causes an issue when trying to retrieve cookbooks from a subversion repository with a self-signed SSL certificate which can usually be accessed using `--trust-server-cert`.

The default attribute setting is set to match what is defined in:
https://github.com/opscode/chef/blob/master/lib/chef/resource/subversion.rb
