### PR TITLE
disable emitting nginx version as a default

### DIFF
--- a/nginx/attributes/nginx.rb
+++ b/nginx/attributes/nginx.rb
@@ -35,6 +35,7 @@ else
   Chef::Log.error "Cannot configure nginx, platform unknown"
 end
 
+default[:nginx][:server_tokens] = 'off'
 default[:nginx][:log_format] = {}
 
 # increase if you accept large uploads

--- a/nginx/templates/default/nginx.conf.erb
+++ b/nginx/templates/default/nginx.conf.erb
@@ -11,6 +11,7 @@ events {
 http {
   include       <%= node[:nginx][:dir] %>/mime.types;
   default_type  application/octet-stream;
+  server_tokens <%= node[:nginx][:server_tokens] %>;
 
   <% node[:nginx][:log_format].each do |name, format| %>
   log_format <%= name %> <%= format %>;


### PR DESCRIPTION
I added `server_tokens: off;` configuration as a default for nginx.conf.

In apache2's recipe has a same configuration.
https://github.com/aws/opsworks-cookbooks/blob/release-chef-11.10/apache2/templates/default/security.erb#L19-L26

Please check and merge this :)
