### PR TITLE
Fix database detection in rails cookbook

### DIFF
--- a/rails/libraries/rails_configuration.rb
+++ b/rails/libraries/rails_configuration.rb
@@ -5,7 +5,7 @@ module OpsWorks
         :consult_gemfile => true,
         :force => false
       }.update(options)
-      if options[:force] || app_config[:database][:adapter].blank?
+      if options[:force] || app_config[:database][:type].blank?
         Chef::Log.info("No database adapter specified for #{app_name}, guessing")
         adapter = ''
 
@@ -30,7 +30,7 @@ module OpsWorks
 
         adapter
       else
-        app_config[:database][:adapter]
+        app_config[:database][:type]
       end
     end
 


### PR DESCRIPTION
As for version 330 of opsworks agent database type reported as 'type', when rails::configure expects 'adapter'.
Because of this bug - there is no way to use rails and postgres rds, database.yml always overridden and it always got wrong adapter type.

``` bash
root@cumulonimbus:/opt/aws/opsworks/current/bin# ./opsworks-agent-cli agent_report

AWS OpsWorks Instance Agent State Report:

  Last activity was a "configure" on 2014-11-24 03:49:19 UTC
  Agent Status: The AWS OpsWorks agent is running as PID 17661
  Agent Version: 330, up to date
```

``` json
root@cumulonimbus:/opt/aws/opsworks/current/bin# ./opsworks-agent-cli get_json | grep -A7 'database\":'
      "database": {
        "host": "*****************************************",
        "database": "************",
        "port": 5432,
        "username": "*****",
        "password": "**********************",
        "reconnect": true,
        "data_source_provider": "rds",
        "type": "postgresql"
      }
```
