### PR TITLE
Adding npm update to nodejs recipe.

### DIFF
--- a/opsworks_nodejs/recipes/default.rb
+++ b/opsworks_nodejs/recipes/default.rb
@@ -37,4 +37,17 @@ else
     notifies :write, "log[downloading]", :immediately
     action :install
   end
+
+  if node[:opsworks_npm][:version]
+    log "downloading" do
+      message "Update npm"
+      level :info
+
+      action :nothing
+    end
+
+    execute "npm update" do
+        command "npm install -g npm@v#{node[:opsworks_npm][:version]}"
+    end
+  end
 end


### PR DESCRIPTION
For users who need npm at greater than the default version, this adds a `opsworks_npm` config with `version` as the only option. If `version` is truthy, npm will be installed at that version.
