### PR TITLE
Issue #270 - fix apache template rendering if no env vars for an app

### DIFF
--- a/apache2/definitions/web_app.rb
+++ b/apache2/definitions/web_app.rb
@@ -40,11 +40,13 @@ define :web_app, :template => 'web_app.conf.erb' do
       cookbook params[:cookbook]
     end
 
-    environment_variables = if node[:deploy][application_name].nil?
-                              {}
-                            else
-                              node[:deploy][application_name][:environment_variables]
-                            end
+    deploy = node[:deploy][application_name]
+    environment_variables = {}    
+
+    if !deploy.nil? && !deploy[:environment_variables].nil?       
+        environment_variables = deploy[:environment_variables] if !deploy[:environment_variables].empty?
+    end
+
     variables(
       :application_name => application_name,
       :params => params,


### PR DESCRIPTION
This is affecting all chef 11.10 instances which have mod_php5_apache2::php in their run list.
