### PR TITLE
Issue #270 - fix apache template rendering if no env vars for an app

### DIFF
--- a/apache2/definitions/web_app.rb
+++ b/apache2/definitions/web_app.rb
@@ -39,12 +39,14 @@ define :web_app, :template => 'web_app.conf.erb' do
     if params[:cookbook]
       cookbook params[:cookbook]
     end
+    
+    deploy = node[:deploy][application_name]
+    environment_variables = {}    
 
-    environment_variables = if node[:deploy][application_name].nil?
-                              {}
-                            else
-                              node[:deploy][application_name][:environment_variables]
-                            end
+    if !deploy.nil? && !deploy[:environment_variables].nil?       
+      environment_variables = deploy[:environment_variables] if !deploy[:environment_variables].empty?
+    end
+
     variables(
       :application_name => application_name,
       :params => params,


### PR DESCRIPTION
#270

This is affecting all chef 11.10 instances which have "mod_php5_apache2::php" in their run list.
