### PR TITLE
Relax pattern used to determine whether ~/.ssh/config should be replaced.

### DIFF
--- a/scm_helper/libraries/git.rb
+++ b/scm_helper/libraries/git.rb
@@ -21,7 +21,7 @@ module OpsWorks
         end
 
         execute "echo 'StrictHostKeyChecking no' > #{options[:home]}/.ssh/config" do
-          not_if "grep '^StrictHostKeyChecking no$' #{options[:home]}/.ssh/config"
+          not_if "grep 'StrictHostKeyChecking no' #{options[:home]}/.ssh/config"
         end
 
         template "#{options[:home]}/.ssh/id_dsa" do


### PR DESCRIPTION
The ssh_config file can contain sections for multiple host patterns. In such cases, the options for a particular host are often indented by a few spaces under each host pattern. By relaxing the pattern used to determine whether StrictHostKeyChecking is enabled, this patch helps avoid replacing the config in some cases where StrictHostKeyChecking is actually turned off but the current behavior would replace the config file anyway.

Specifically, we had a ssh_config dropped by another recipe that looked something like:

```
Host *
  ...
  StrictHostKeyChecking no
  ...
```

but was being overwritten by the one-line ssh config in Opsworks::SCM::Git#prepare_git_checkouts because the current pattern doesn't allow leading whitespace.
