### PR TITLE
DRY: Include the "haproxy::service" recipe

### DIFF
--- a/haproxy/recipes/configure.rb
+++ b/haproxy/recipes/configure.rb
@@ -1,7 +1,4 @@
-service "haproxy" do
-  supports :restart => true, :status => true, :reload => true
-  action :nothing # only define so that it can be restarted if the config changed
-end
+include_recipe "haproxy::service"
 
 template "/etc/haproxy/haproxy.cfg" do
   cookbook "haproxy"


### PR DESCRIPTION
Don't Repeat Yourself: Include the "haproxy::service" recipe here instead of defining it the exact same way in 2 places.
