### PR TITLE
haproxy: Block SSLv3 requests to mitigate POODLE

### DIFF
--- a/haproxy/templates/default/haproxy.cfg.erb
+++ b/haproxy/templates/default/haproxy.cfg.erb
@@ -265,7 +265,12 @@ frontend http-in
 frontend https-in
   mode tcp
   bind :443
-  
+
+  # Block SSLv3 requests to mitigate POODLE attacks
+  tcp-request inspect-delay 2s
+  acl is_sslv3 req_ssl_ver 3
+  tcp-request content reject if is_sslv3
+
   # all domains of Rails applications
   <% node[:haproxy][:rails_applications].each do |app_name, app_config| -%>
     <% app_config['domains'].each do |domain| -%>


### PR DESCRIPTION
haproxy: Block SSLv3 requests in order to mitigate POODLE attacks.

**Related blog post:** http://blog.haproxy.com/2014/10/15/haproxy-and-sslv3-poodle-vulnerability/

The only thing I'm unsure of now is if doing this makes the `option ssl-hello-chk` always failing since the haproxy documentation mentions that `ssl-hello-chk` sends pure SSLv3 client hello messages. However, I _**believe**_ that those `ssl-hello-chk` messages will probably continue working correctly since they are being sent to backend servers, not to the frontend proxies.
