### PR TITLE
[php] remove quotes around boolean literals in opsworks.php

### DIFF
--- a/php/templates/default/opsworks.php.erb
+++ b/php/templates/default/opsworks.php.erb
@@ -11,7 +11,7 @@ class OpsWorksDb {
     $this->host = '<%= @database[:host] %>';
     $this->username = '<%= @database[:username] %>';
     $this->password = '<%= @database[:password] %>';
-    $this->reconnect = '<%= @database[:reconnect] ? 'true' : 'false' %>';
+    $this->reconnect = <%= @database[:reconnect] ? 'true' : 'false' %>;
   }
 }
 


### PR DESCRIPTION
Both `'true'` and `'false'` (with quotes) evaluate to `true`, so essentially this setting is useless in its current form.
