### PR TITLE
Fixing unexplicable interface ip (typo)?

### DIFF
--- a/opsworks_stack_state_sync/templates/default/hosts.erb
+++ b/opsworks_stack_state_sync/templates/default/hosts.erb
@@ -10,8 +10,7 @@ ff02::2 ip6-allrouters
 ff02::3 ip6-allhosts
 
 # OpsWorks Layer State
-127.0.0.1 localhost.localdomain localhost
-127.0.1.1 <%= @localhost_name %>.localdomain <%= @localhost_name %>
+127.0.0.1 <%= @localhost_name %>.localdomain <%= @localhost_name %>
 
 <% @nodes.each do |node| -%>
 <% if node.attributes.attribute?(:private_ip) && node.attributes.private_ip && Resolv.getaddress(node.attributes.private_ip) -%>


### PR DESCRIPTION
I tried to reach to you through the comments see [here](https://github.com/aws/opsworks-cookbooks/commit/114fa829d57bfc972c449b3cf3c48c11ebc214c1#comments) regarding this discrepancy with the local loopback interface. This looks like a typo, where the loopback interface is marked as `127.0.1.1` instead of `127.0.0.1`. This simple pull request makes the fix, if there's any. I'd really appreciate if you can elaborate on this regard.
