### PR TITLE
Disable SSLv3 from Apache to prevent POODLE Attack

### DIFF
--- a/apache2/templates/default/mods/ssl.conf.erb
+++ b/apache2/templates/default/mods/ssl.conf.erb
@@ -67,6 +67,6 @@ SSLCipherSuite HIGH:MEDIUM:!ADH
 #SSLCipherSuite ALL:!ADH:!EXPORT56:RC4+RSA:+HIGH:+MEDIUM:+LOW:+SSLv2:+EXP:+eNULL
 
 # enable only secure protocols: SSLv3 and TLSv1, but not SSLv2
-SSLProtocol all -SSLv2
+SSLProtocol all -SSLv2 -SSLv3
 
 </IfModule>

--- a/apache2/templates/ubuntu-14.04/mods/ssl.conf.erb
+++ b/apache2/templates/ubuntu-14.04/mods/ssl.conf.erb
@@ -74,7 +74,7 @@
 	#   The protocols to enable.
 	#   Available values: all, SSLv3, TLSv1, TLSv1.1, TLSv1.2
 	#   SSL v2  is no longer supported
-	SSLProtocol all
+	SSLProtocol all -SSLv3
 
 	#   Allow insecure renegotiation with clients which do not yet support the
 	#   secure renegotiation protocol. Default: Off


### PR DESCRIPTION
This pull request removes SSLv3 from the list of SSL Protocols allowed in Apache.
To prevent POODLE Attack using SSLv3.
