### PR TITLE
Make Nginx Keep-Alive Timeout configurable

### DIFF
--- a/unicorn/templates/default/nginx_unicorn_web_app.erb
+++ b/unicorn/templates/default/nginx_unicorn_web_app.erb
@@ -14,7 +14,7 @@ server {
   access_log <%= node[:nginx][:log_dir] %>/<%= @application[:domains].first %>.access.log;
   <%end %>
 
-  keepalive_timeout 5;
+  keepalive_timeout <%= node[:nginx][:keepalive_timeout] %>;
 
   root <%= @application[:absolute_document_root] %>;
 


### PR DESCRIPTION
In order to investigate regularly occurring HTTP 504 Gateway Timeout errors (in the ELB logs and in CloudWatch) I had a longer AWS support session which discovered:
- when using an ELB (which has a 60s keep-alive timeout), you should better set the Nginx's keep-alive timeout a few seconds higher than the ELB's. See http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/ts-elb-error-message.html#ts-elb-errorcodes-http504
- changing `node[:nginx][:keepalive_timeout]` in the stack settings writes this value as expected into `/etc/nginx/nginx.conf`, but this unicorn nginx template overrides the value in `/etc/nginx/sites-enabled/myapp` with hardcoded 5s, so the change has no effect.
