### PR TITLE
Added support for Tomcat 8

### DIFF
--- a/deploy/recipes/java.rb
+++ b/deploy/recipes/java.rb
@@ -12,9 +12,9 @@ node[:deploy].each do |application, deploy|
     connector_jar_path = ::File.join(node['opsworks_java']['tomcat']['java_shared_lib_dir'], connector_jar)
     include_recipe "opsworks_java::mysql_connector"
   when "postgresql"
-    connector_jar = node[:platform].eql?('ubuntu') ? 'postgresql-jdbc4.jar' : 'postgresql-jdbc.jar'
+    connector_jar = 'postgresql-9.4.jdbc41.jar'; 
     connector_jar_path = ::File.join(node['opsworks_java']['tomcat']['java_shared_lib_dir'], connector_jar)
-    include_recipe "opsworks_java::postgresql_connector"
+    include_recipe "opsworks_java::postgresql_connector9"
   else
     connector_jar = ""
     connector_jar_path = ""

--- a/deploy/recipes/java.rb
+++ b/deploy/recipes/java.rb
@@ -12,9 +12,9 @@ node[:deploy].each do |application, deploy|
     connector_jar_path = ::File.join(node['opsworks_java']['tomcat']['java_shared_lib_dir'], connector_jar)
     include_recipe "opsworks_java::mysql_connector"
   when "postgresql"
-    connector_jar = 'postgresql-9.4.jdbc41.jar'; 
+    connector_jar = node[:platform].eql?('ubuntu') ? 'postgresql-jdbc4.jar' : 'postgresql-jdbc.jar' 
     connector_jar_path = ::File.join(node['opsworks_java']['tomcat']['java_shared_lib_dir'], connector_jar)
-    include_recipe "opsworks_java::postgresql_connector9"
+    include_recipe "opsworks_java::postgresql_connector"
   else
     connector_jar = ""
     connector_jar_path = ""

--- a/opsworks_java/recipes/postgresql9_connector.rb
+++ b/opsworks_java/recipes/postgresql9_connector.rb
@@ -1,0 +1,9 @@
+jdbc_jar = ::File.join(node['opsworks_java']['tomcat']['java_shared_lib_dir'], 'postgresql-9.4.jdbc41.jar')
+
+remote_file jdbc_jar do
+  source 'https://jdbc.postgresql.org/download/postgresql-9.4-1201.jdbc41.jar'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  action :create
+end

--- a/opsworks_java/templates/default/server.xml.erb
+++ b/opsworks_java/templates/default/server.xml.erb
@@ -4,6 +4,10 @@
      Documentation at /docs/config/server.html
  -->
 <Server port="<%= node['opsworks_java']['tomcat']['shutdown_port'] %>" shutdown="SHUTDOWN">
+
+<% if node['opsworks_java']['tomcat']['base_version'].to_i > 7 -%>
+  <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+<% end -%>
 <% if node['opsworks_java']['tomcat']['base_version'].to_i > 6 -%>
   <!-- Security listener. Documentation at /docs/config/listeners.html
   <Listener className="org.apache.catalina.security.SecurityListener" />
@@ -11,8 +15,10 @@
 <% end -%>
   <!--APR library loader. Documentation at /docs/apr.html -->
   <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+<% if node['opsworks_java']['tomcat']['base_version'].to_i < 8 -%>
   <!--Initialize Jasper prior to webapps are loaded. Documentation at /docs/jasper-howto.html -->
   <Listener className="org.apache.catalina.core.JasperListener" />
+<% end -%>
   <!-- Prevent memory leaks due to use of particular java/javax APIs-->
   <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
 <% if node['opsworks_java']['tomcat']['base_version'].to_i < 7 -%>


### PR DESCRIPTION
When specifying version 8 in custom json tomcat 8 failed to start. 

{
  "opsworks_java": {
    "java_app_server_version" : 8
  }
}

This change removes the JasperListener when the requested version is > 7.
