### PR TITLE
Fix #ensure_only_gem_version bug

### DIFF
--- a/dependencies/libraries/current_gem_version.rb
+++ b/dependencies/libraries/current_gem_version.rb
@@ -3,7 +3,8 @@ module OpsWorks
     require 'rubygems/version'
 
     def ensure_only_gem_version(name, ensured_version)
-      versions = `#{node[:dependencies][:gem_binary]} list #{name}`
+      gem_list_output = `#{node[:dependencies][:gem_binary]} list #{name}`
+      name, versions = gem_list_output.split(/\s/, 2)
       versions = versions.scan(/(\d[a-zA-Z0-9\.]*)/).flatten.compact
       for version in versions
         next if version == ensured_version


### PR DESCRIPTION
When a gem such as 'fluent-plugin-s3' is passed to #ensure_only_gem_version,
the `versions` variable is set to an array which includes wrong version number like ["3", "0.5.10", "0.5.12"].

This commit solves the above issue.

before

``` ruby
gem_list = "some-gem3 (3.2.0, 3.0.2, 3.0.1)"
versions = gem_list.scan(/(\d[a-zA-Z0-9\.]*)/).flatten.compact
p versions # => ["3", "3.2.0", "3.0.2", "3.0.1"]
```

after

``` ruby
gem_list = "some-gem3 (3.2.0, 3.0.2, 3.0.1)"
name, versions = gem_list.split(/\s/, 2)
versions = versions.scan(/(\d[a-zA-Z0-9\.]*)/).flatten.compact
p versions # => ["3.2.0", "3.0.2", "3.0.1"]
```
