### PR TITLE
shared directory subdirectories moved to variable

### DIFF
--- a/deploy/attributes/deploy.rb
+++ b/deploy/attributes/deploy.rb
@@ -95,6 +95,7 @@ node[:deploy].each do |application, deploy|
   default[:deploy][application][:enable_submodules] = true
   default[:deploy][application][:shallow_clone] = false
   default[:deploy][application][:delete_cached_copy] = true
+  default[:deploy][application][:shared_subdirectories] = ['log','config','system','pids','scripts','sockets']
   default[:deploy][application][:purge_before_symlink] = ['log', 'tmp/pids', 'public/system']
   default[:deploy][application][:create_dirs_before_symlink] = ['tmp', 'public', 'config']
   default[:deploy][application][:symlink_before_migrate] = {}

--- a/deploy/definitions/opsworks_deploy_dir.rb
+++ b/deploy/definitions/opsworks_deploy_dir.rb
@@ -32,7 +32,7 @@ define :opsworks_deploy_dir do
   end
 
   # create shared/ directory structure
-  ['log','config','system','pids','scripts','sockets'].each do |dir_name|
+  params[:shared_subdirectories].each do |dir_name|
     directory "#{params[:path]}/shared/#{dir_name}" do
       group params[:group]
       owner params[:user]

--- a/deploy/recipes/aws-flow-ruby.rb
+++ b/deploy/recipes/aws-flow-ruby.rb
@@ -11,6 +11,7 @@ node[:deploy].each do |application, deploy|
     user deploy[:user]
     group deploy[:group]
     path deploy[:deploy_to]
+    shared_subdirectories deploy[:shared_subdirectories]
   end
 
   opsworks_deploy do

--- a/deploy/recipes/java.rb
+++ b/deploy/recipes/java.rb
@@ -37,6 +37,7 @@ node[:deploy].each do |application, deploy|
     user deploy[:user]
     group deploy[:group]
     path deploy[:deploy_to]
+    shared_subdirectories deploy[:shared_subdirectories]
   end
 
   opsworks_deploy do

--- a/deploy/recipes/nodejs.rb
+++ b/deploy/recipes/nodejs.rb
@@ -10,6 +10,7 @@ node[:deploy].each do |application, deploy|
     user deploy[:user]
     group deploy[:group]
     path deploy[:deploy_to]
+    shared_subdirectories deploy[:shared_subdirectories]
   end
 
   opsworks_deploy do

--- a/deploy/recipes/php.rb
+++ b/deploy/recipes/php.rb
@@ -17,6 +17,7 @@ node[:deploy].each do |application, deploy|
     user deploy[:user]
     group deploy[:group]
     path deploy[:deploy_to]
+    shared_subdirectories deploy[:shared_subdirectories]
   end
 
   opsworks_deploy do
@@ -24,4 +25,3 @@ node[:deploy].each do |application, deploy|
     app application
   end
 end
-

--- a/deploy/recipes/rails.rb
+++ b/deploy/recipes/rails.rb
@@ -11,6 +11,7 @@ node[:deploy].each do |application, deploy|
     user deploy[:user]
     group deploy[:group]
     path deploy[:deploy_to]
+    shared_subdirectories deploy[:shared_subdirectories]
   end
 
   opsworks_rails do

--- a/deploy/recipes/web.rb
+++ b/deploy/recipes/web.rb
@@ -11,6 +11,7 @@ node[:deploy].each do |application, deploy|
     user deploy[:user]
     group deploy[:group]
     path deploy[:deploy_to]
+    shared_subdirectories deploy[:shared_subdirectories]
   end
 
   opsworks_deploy do

--- a/unicorn/recipes/rails.rb
+++ b/unicorn/recipes/rails.rb
@@ -20,6 +20,7 @@ node[:deploy].each do |application, deploy|
     user deploy[:user]
     group deploy[:group]
     path deploy[:deploy_to]
+    shared_subdirectories deploy[:shared_subdirectories]
   end
 
   template "#{deploy[:deploy_to]}/shared/scripts/unicorn" do


### PR DESCRIPTION
In certain scenarios you might want to customize shared directory structure (e.g. to symlink shared node_modules/). In this PR I've moved array of directories to be created under shared/ into customizable variable.
