### PR TITLE
Avoid recreating group

### DIFF
--- a/deploy/definitions/opsworks_deploy_user.rb
+++ b/deploy/definitions/opsworks_deploy_user.rb
@@ -1,7 +1,13 @@
 define :opsworks_deploy_user do
   deploy = params[:deploy_data]
 
-  group deploy[:group]
+  group deploy[:group] do
+    not_if do
+      existing_groups = []
+      Etc.group {|group| existing_groups << group['name']}
+      existing_groups.include?(deploy[:group])
+    end
+  end
 
   user deploy[:user] do
     action :create


### PR DESCRIPTION
This prevents some file permission problems when others users are also added to deploy group .
