### PR TITLE
Fix opsworks_java::jvm_install for installing only JVM

### DIFF
--- a/opsworks_java/recipes/jvm_install.rb
+++ b/opsworks_java/recipes/jvm_install.rb
@@ -78,5 +78,3 @@ remote_file local_custom_pkg_file do
     notifies :run, "execute[extract #{local_custom_pkg_file} to #{node['opsworks_java']['jvm_pkg']['java_home_basedir']}]", :immediately
   end
 end
-
-include_recipe 'opsworks_java::tomcat_setup'

--- a/opsworks_java/recipes/setup.rb
+++ b/opsworks_java/recipes/setup.rb
@@ -1,1 +1,2 @@
 include_recipe 'opsworks_java::jvm_install'
+include_recipe 'opsworks_java::tomcat_setup'


### PR DESCRIPTION
Hi everyone

`opsworks_java::jvm_install` recipe installs not only JVM but also Tomcat.
So I made changes that `opsworks_java::setup` recipe keeps to install both JVM and Tomcat and `opsworks_java::jvm_install` recipe installs only JVM.
