### PR TITLE
Output migration error messages to chef log on failure.

### DIFF
--- a/opsworks_commons/libraries/monkey_patch_deploy_provider.rb
+++ b/opsworks_commons/libraries/monkey_patch_deploy_provider.rb
@@ -42,7 +42,7 @@ class Chef
             else
               Chef::Log.info "#{@new_resource} migrating #{@new_resource.user}"
             end
-            run_command(run_options(:command => @new_resource.migration_command, :cwd=>release_path, :log_level => :info))
+            run_command(run_options(:command => @new_resource.migration_command, :cwd=>release_path, :output_on_failure => true))
           end
         end
       end


### PR DESCRIPTION
The current monkey-patch does not have the correct option to output migration failure information to the Chef logs.

These are the params the `run_command` method considers in the hash:

```
command<String>, <Array>: A complete command with options to execute or a command and options as an Array
creates<String>: The absolute path to a file that prevents the command from running if it exists
cwd<String>: Working directory to execute command in, defaults to Dir.tmpdir
timeout<String>: How many seconds to wait for the command to execute before timing out
returns<String>: The single exit value command is expected to return, otherwise causes an exception
ignore_failure<Boolean>: Whether to raise an exception on failure, or just return the status
output_on_failure<Boolean>: Return output in raised exception regardless of Log.level

user<String>: The UID or user name of the user to execute the command as
group<String>: The GID or group name of the group to execute the command as
environment<Hash>: Pairs of environment variable names and their values to set before execution
```

And here's the relevant lines in Chef: https://github.com/chef/chef/blob/11.10.0/lib/chef/mixin/command.rb#L153-L157

``` ruby
if Chef::Log.level == :debug || opts[:output_on_failure]
  output << "\n---- Begin output of #{opts[:command]} ----\n"
  output << command_output.to_s
  output << "\n---- End output of #{opts[:command]} ----\n"
end
```
