### PR TITLE
Fix mysql client and server installation for CentOS 7

### DIFF
--- a/mysql/attributes/server.rb
+++ b/mysql/attributes/server.rb
@@ -26,6 +26,9 @@ default[:mysql][:server_root_password] = root_pw
 if rhel7?
   default[:mysql][:name] = "mysql55-mysql"
   default[:mysql][:bin_dir] = "/opt/rh/mysql55/root/usr/bin"
+  if platform?('centos') && node[:platform_version].to_f > 7
+    default[:mysql][:bin_dir] = "/bin"
+  end
 else
   default[:mysql][:name] = "mysql"
   default[:mysql][:bin_dir] = "/usr/bin"

--- a/mysql/recipes/client_install.rb
+++ b/mysql/recipes/client_install.rb
@@ -17,7 +17,11 @@ end
 
 case node[:platform]
 when "redhat", "centos", "fedora", "amazon"
-  package mysql_name
+  if rhel7?
+    package "mariadb"
+  else
+    package mysql_name
+  end
 else "ubuntu"
   package "mysql-client"
 end

--- a/mysql/recipes/config.rb
+++ b/mysql/recipes/config.rb
@@ -12,3 +12,21 @@ template 'mysql configuration' do
   mode 0644
   notifies :restart, "service[mysql]"
 end
+
+# CentOS 7 mariadb vs. mysql directory hickup fix
+if platform?('centos') && node[:platform_version].to_i >= 7
+  execute "Move mariadb log dir" do
+    command "mv /var/log/mariadb #{node[:mysql][:logdir]}"
+     not_if do
+       ( FileTest.directory?(node[:mysql][:logdir]) || !FileTest.directory?("/var/log/mariadb") )
+     end
+  end
+
+  pidfile_directory = File.dirname(node[:mysql][:pid_file])  
+  execute "Move mariadb pidfile directory" do
+    command "mv /var/run/mariadb #{pidfile_directory}"
+    not_if do
+      ( FileTest.directory?(pidfile_directory) || !FileTest.directory?("/var/run/mariadb") )
+    end
+  end
+end

--- a/mysql/recipes/server.rb
+++ b/mysql/recipes/server.rb
@@ -6,7 +6,11 @@ include_recipe 'mysql::prepare'
 # for backwards compatiblity default the package name to mysql
 mysql_name = node[:mysql][:name] || "mysql"
 
-package "#{mysql_name}-server"
+if platform?('centos') && node[:platform_version].to_f > 7
+  package "mariadb-server"
+else
+  package "#{mysql_name}-server"
+end
 
 if platform?('ubuntu') && node[:platform_version].to_f < 10.04
   remote_file '/tmp/mysql_init.patch' do

--- a/mysql/recipes/service.rb
+++ b/mysql/recipes/service.rb
@@ -4,7 +4,11 @@ mysql_name = node[:mysql][:name] || "mysql"
 service "mysql" do
   case node[:platform]
   when "redhat", "centos", "fedora", "amazon"
-    service_name "#{mysql_name}d"
+    if platform?('centos') && node[:platform_version].to_i >= 7
+      service_name "mariadb"
+	else
+	  service_name "#{mysql_name}d"
+    end
   else
     service_name "mysql"
   end


### PR DESCRIPTION
Running these cookbooks on a local vm CentOS 7 instances fails.
mysql::client_install fails when trying to install the package "mysql55_client" which is not available on a standard CentOS 7 installation. The correct package together with "mariadb-devel" is "mariadb".

Similar issues regarding mariadb-server and init.d scripts as well as some minor path issues occur for the mysql::server recipie on CentOS7.
