### PR TITLE
Bump Ruby to version 2.2.4

### DIFF
--- a/ruby/attributes/ruby.rb
+++ b/ruby/attributes/ruby.rb
@@ -21,7 +21,7 @@ case node["opsworks"]["ruby_version"]
 when "2.2"
   default[:ruby][:major_version] = '2'
   default[:ruby][:minor_version] = '2'
-  default[:ruby][:patch_version] = '3'
+  default[:ruby][:patch_version] = '4'
   default[:ruby][:pkgrelease]    = '1'
 
   default[:ruby][:full_version] = [node[:ruby][:major_version], node[:ruby][:minor_version]].join(".")


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2015/12/16/ruby-2-2-4-released/

"There is an unsafe tainted string vulnerability in Fiddle and DL."
