### PR TITLE
Fix for SSL canonical host redirect URL scheme

### DIFF
--- a/passenger_apache2/templates/default/web_app.conf.erb
+++ b/passenger_apache2/templates/default/web_app.conf.erb
@@ -145,7 +145,7 @@
   # Canonical host
   #RewriteCond %{HTTP_HOST}   !^<%= @params[:server_name] %> [NC]
   #RewriteCond %{HTTP_HOST}   !^$
-  #RewriteRule ^/(.*)$        http://<%= @params[:server_name] %>/$1 [L,R=301]
+  #RewriteRule ^/(.*)$        https://<%= @params[:server_name] %>/$1 [L,R=301]
 
   RewriteCond %{REQUEST_URI} !\.(css|gif|jpg|jpeg|png)$
   RewriteCond %{DOCUMENT_ROOT}/system/maintenance.html -f


### PR DESCRIPTION
Changing the SSL canonical host redirect to redirect to HTTP instead of HTTP
