### PR TITLE
Add schema_search_path capability to database.yml.erb

### DIFF
--- a/rails/templates/default/database.yml.erb
+++ b/rails/templates/default/database.yml.erb
@@ -13,5 +13,8 @@
 <% if @database[:port] -%>
   port: <%= @database[:port].to_i.inspect %>
 <% end -%>
+<% if @database[:schema_search_path] -%>
+  schema_search_path: <%= @database[:schema_search_path].to_s.inspect %>
+<% end -%>
 
 <% end %>


### PR DESCRIPTION
This is useful for PostgreSQL projects, so we can use methods from extensions such as postgis without prefixing.
