### PR TITLE
set ECS_AVAILABLE_LOGGING_DRIVERS to include awslogs

### DIFF
--- a/opsworks_ecs/templates/default/ecs.config.erb
+++ b/opsworks_ecs/templates/default/ecs.config.erb
@@ -2,3 +2,4 @@ ECS_LOGFILE=/log/ecs-agent.log
 ECS_LOGLEVEL=<%= node["opsworks_ecs"]["ecs-agent"]["loglevel"] %>
 ECS_DATADIR=/data
 ECS_CLUSTER=<%= node["opsworks_ecs"]["ecs_cluster_name"] %>
+ECS_AVAILABLE_LOGGING_DRIVERS=["json-file","awslogs"]


### PR DESCRIPTION
Set `ECS_AVAILABLE_LOGGING_DRIVERS` to `["json-file","awslogs"]`.  This is suggested by http://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html

Fixes #385
