### PR TITLE
Fix log_format config

### DIFF
--- a/nginx/templates/default/default-site.erb
+++ b/nginx/templates/default/default-site.erb
@@ -2,7 +2,7 @@ server {
   listen   80;
   server_name  127.0.0.1;
 
-  access_log  <%= node[:nginx][:log_dir] %>/localhost.access.log;
+  access_log  <%= node[:nginx][:log_dir] %>/localhost.access.log <%= node[:nginx][:log_format][:name] %>;
 
   location / {
     root   /var/www/nginx-default;


### PR DESCRIPTION
This PR adds the log_format configured into the default-site template configuration file. Otherwise the #PR81 won't work without I create a new recipe to re-do the work. I confirm Apache 2.0 licence.
