### PR TITLE
It Makes the default answers be  used  for  all  questions.

### DIFF
--- a/dependencies/recipes/update.rb
+++ b/dependencies/recipes/update.rb
@@ -57,7 +57,7 @@ when 'debian','ubuntu'
   end
 
   if node[:dependencies][:upgrade_debs]
-    execute 'apt-get upgrade -y' do
+    execute 'DEBIAN_FRONTEND=noninteractive apt-get upgrade -y' do
       action :run
     end
   end


### PR DESCRIPTION
This flag is to avoid errors on interactive session on apt-get upgrade.

**Ref:** [http://manpages.ubuntu.com/manpages/xenial/man7/debconf.7.html](http://manpages.ubuntu.com/manpages/xenial/man7/debconf.7.html)

**Example:**
```
Setting up sudo (1.8.9p5-1ubuntu1.3) ...
STDERR: debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (This frontend requires a controlling tty.)
debconf: falling back to frontend: Teletype
dpkg-preconfigure: unable to re-open stdin: 
 
Configuration file '/etc/sudoers'
==> Modified (by you or by a script) since installation.
==> Package distributor has shipped an updated version.
What would you like to do about it ?  Your options are:
Y or I  : install the package maintainer's version
N or O  : keep your currently-installed version
D     : show the differences between the versions
Z     : start a shell to examine the situation
The default action is to keep your current version.
*** sudoers (Y/I/N/O/D/Z) [default=N] ? dpkg: error processing package sudo (--configure):
EOF on stdin at conffile prompt
Errors were encountered while processing:
sudo
E: Sub-process /usr/bin/dpkg returned an error code (1)
```