### PR TITLE
Update client_install.rb

### DIFF
--- a/opsworks_postgresql/recipes/client_install.rb
+++ b/opsworks_postgresql/recipes/client_install.rb
@@ -12,8 +12,11 @@ else
   # old behavior for backwards compatibility
   package "postgresql-devel" do
     package_name value_for_platform(
-      ["centos","redhat","fedora","amazon"] => {"default" => "postgresql-devel"},
+      ["centos","redhat","fedora","amazon"] => {"default" => "postgresql8-devel"},
       "ubuntu" => {"default" => "libpq-dev"}
+    )
+    version value_for_platform(
+      ["centos","redhat","fedora","amazon"] => {"default" => "8.4.20-4.51.amzn1"}
     )
     action :install
     retries 3


### PR DESCRIPTION
fix for error ...

[2017-08-09T14:02:28+00:00] INFO: Processing execute[passenger_module] action run (passenger_apache2::default line 61)
[2017-08-09T14:02:28+00:00] INFO: Processing bash[Enable selinux httpd_t for passenger] action run (passenger_apache2::default line 67)
[2017-08-09T14:02:28+00:00] INFO: Processing template[/etc/httpd/mods-available/passenger.load] action create (passenger_apache2::mod_rails line 37)
[2017-08-09T14:02:28+00:00] INFO: Processing template[/etc/httpd/mods-available/passenger.conf] action create (passenger_apache2::mod_rails line 46)
[2017-08-09T14:02:28+00:00] INFO: Processing file[/etc/httpd/mods-available/passenger.load] action create (passenger_apache2::mod_rails line 31)
[2017-08-09T14:02:28+00:00] INFO: Processing execute[a2enmod passenger] action run (passenger_apache2::mod_rails line 38)
[2017-08-09T14:02:28+00:00] INFO: Processing execute[stop unicorn] action run (unicorn::stop line 8)
[2017-08-09T14:02:28+00:00] INFO: Processing group[apache] action create (deploy::default line 4)
[2017-08-09T14:02:28+00:00] INFO: Processing user[deploy] action create (deploy::default line 6)
[2017-08-09T14:02:28+00:00] INFO: Processing package[postgresql-devel] action install (opsworks_postgresql::client_install line 5)
[2017-08-09T14:02:32+00:00] WARN: package[postgresql-devel] matched multiple Provides for postgresql-devel but we can only use the first match: postgresql8-devel. Please use a more specific version.
[2017-08-09T14:02:32+00:00] INFO: package[postgresql-devel] installing postgresql8-devel-8.4.20-4.51.amzn1 from amzn-updates repository
 
================================================================================
Error executing action `install` on resource 'package[postgresql-devel]'
================================================================================
 
 
Chef::Exceptions::Exec
----------------------
returned 1, expected 0
 
 
Resource Declaration:
---------------------
# In /var/lib/aws/opsworks/cache.stage2/cookbooks/opsworks_postgresql/recipes/client_install.rb
 
5:     package pkg do
6:       action :install
7:     end
8:   end
 
 
 
Compiled Resource:
------------------
# Declared in /var/lib/aws/opsworks/cache.stage2/cookbooks/opsworks_postgresql/recipes/client_install.rb:5:in `block in from_file'
 
package("postgresql-devel") do
action [:install]
retries 0
retry_delay 2
package_name "postgresql8-devel"
version "8.4.20-4.51.amzn1"
cookbook_name "opsworks_postgresql"
recipe_name "client_install"
end
 
 
 
[2017-08-09T14:02:33+00:00] INFO: Running queued delayed notifications before re-raising exception
[2017-08-09T14:02:33+00:00] INFO: bash[logdir_existence_and_restart_apache2] sending restart action to service[apache2] (delayed)
[2017-08-09T14:02:33+00:00] INFO: Processing service[apache2] action restart (apache2::default line 32)
[2017-08-09T14:02:35+00:00] INFO: service[apache2] restarted
[2017-08-09T14:02:35+00:00] ERROR: Running exception handlers
[2017-08-09T14:02:35+00:00] ERROR: Exception handlers complete
[2017-08-09T14:02:35+00:00] FATAL: Stacktrace dumped to /var/lib/aws/opsworks/cache.stage2/chef-stacktrace.out
[2017-08-09T14:02:35+00:00] ERROR: package[postgresql-devel] (opsworks_postgresql::client_install line 5) had an error: Chef::Exceptions::Exec:  returned 1, expected 0
[2017-08-09T14:02:36+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)