### PR TITLE
Master chef 11.10 - bump ruby version 2.3 to 2.3.5

### DIFF
--- a/opsworks_cloudwatchlogs/attributes/default.rb
+++ b/opsworks_cloudwatchlogs/attributes/default.rb
@@ -1,12 +1,15 @@
-if node["platform"] == "amazon"
-  default["cloudwatchlogs"]["config_file"] = "/etc/awslogs/awslogs.conf" # Configures the logs for the agent to ship
-  default["cloudwatchlogs"]["home_dir"] = "/etc/awslogs" # Contains configuration files
-  default["cloudwatchlogs"]["state_file"] = "/var/lib/awslogs/agent-state" # See http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/QuickStartChef.html
-else
-  default["cloudwatchlogs"]["config_file"] = "/opt/aws/cloudwatch/cwlogs.cfg" # Configures the logs to ship, used by installation script
-  default["cloudwatchlogs"]["home_dir"] = "/var/awslogs" # Contains the awslogs package
-  default["cloudwatchlogs"]["state_file"] = "/var/awslogs/state/agent-state" # See http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/QuickStartChef.html
-end
+default["cloudwatchlogs"]["config_file"] = "/opt/aws/cloudwatch/cwlogs.cfg"
+default["cloudwatchlogs"]["home_dir"] = "/opt/aws/cloudwatch"
+default["cloudwatchlogs"]["state_file_dir"] = "/var/awslogs/state"
 
-default["cloudwatchlogs"]["AGENT_LOGS"] = "/var/log/aws/opsworks/*.log"
-default["cloudwatchlogs"]["CHEF_LOGS"] = "/var/lib/aws/opsworks/chef/*.log"
+hostname = node["opsworks"]["instance"]["hostname"]
+instance_layers = node["opsworks"]["instance"]["layers"]
+
+# Collect log_streams from all layers that the instance is attached to
+# Set the default log_stream_name to be the opsworks instance id
+default["cloudwatchlogs"]["log_streams"] = instance_layers.map do |layer_name|
+  cloud_watch_logs_configuration = node["opsworks"]["layers"][layer_name].fetch("cloud_watch_logs_configuration", {})
+  enabled = cloud_watch_logs_configuration["enabled"]
+  log_streams = cloud_watch_logs_configuration["log_streams"]
+  log_streams.map { |stream| { "log_stream_name" => hostname }.merge(stream) } unless log_streams.nil? || !enabled
+end.compact.flatten

--- a/opsworks_cloudwatchlogs/recipes/default.rb
+++ b/opsworks_cloudwatchlogs/recipes/default.rb
@@ -1,5 +1,5 @@
-if node["opsworks"]["cloud_watch_logs_configurations"].any?
+if node["cloudwatchlogs"]["log_streams"].any?
   include_recipe "opsworks_cloudwatchlogs::install"
 else
-  include_recipe "opsworks_cloudwatchlogs::uninstall"
+  include_recipe "opsworks_cloudwatchlogs::uninstall" if File.exists?(File.join(node["cloudwatchlogs"]["home_dir"], "INSTALLED_BY_OPSWORKS"))
 end

--- a/opsworks_cloudwatchlogs/recipes/install.rb
+++ b/opsworks_cloudwatchlogs/recipes/install.rb
@@ -1,49 +1,39 @@
-directory node["cloudwatchlogs"]["home_dir"] do
-  recursive true
+[node["cloudwatchlogs"]["home_dir"], node["cloudwatchlogs"]["state_file_dir"]].each do |dir|
+  directory dir do
+    recursive true
+  end
 end
 
 template node["cloudwatchlogs"]["config_file"] do
   source "awslogs.conf.erb"
   variables({
-    :state_file => node["cloudwatchlogs"]["state_file"],
-    :cloudwatchlogs => node["opsworks"]["cloud_watch_logs_configurations"],
-    :hostname => node["opsworks"]["instance"]["hostname"]
+    :state_file_dir => node["cloudwatchlogs"]["state_file_dir"],
+    :log_streams => node["cloudwatchlogs"]["log_streams"]
   })
   owner "root"
   group "root"
   mode 0644
 end
 
-if platform?("amazon")
-  package "awslogs" do
-    retries 3
-    retry_delay 5
-  end
+remote_file "/opt/aws/cloudwatch/awslogs-agent-setup.py" do
+  source "https://aws-cloudwatch.s3.amazonaws.com/downloads/latest/awslogs-agent-setup.py"
+  mode 0700
+  retries 3
+  retry_delay 5
+end
 
-  template "#{node['cloudwatchlogs']['home_dir']}/awscli.conf" do
-    source "awscli.conf.erb"
-    variables :region => node["opsworks"]["instance"]["region"]
-  end
-else
-  directory "/opt/aws/cloudwatch" do
-    recursive true
-  end
+package "python" do
+  retries 3
+  retry_delay 5
+end
 
-  remote_file "/opt/aws/cloudwatch/awslogs-agent-setup.py" do
-    source "https://aws-cloudwatch.s3.amazonaws.com/downloads/latest/awslogs-agent-setup.py"
-    mode 0700
-    retries 3
-  end
+execute "Install CloudWatch Logs agent" do
+  command "/opt/aws/cloudwatch/awslogs-agent-setup.py -n -r '#{node['opsworks']['instance']['region']}' -c '#{node['cloudwatchlogs']['config_file']}'"
+  creates File.join(node["cloudwatchlogs"]["state_file_dir"], "state_file")
+end
 
-  package "python" do
-    retries 3
-    retry_delay 5
-  end
-
-  execute "Install CloudWatch Logs agent" do
-    command "/opt/aws/cloudwatch/awslogs-agent-setup.py -n -r '#{node['opsworks']['instance']['region']}' -c '#{node['cloudwatchlogs']['config_file']}'"
-    not_if { File.exists?(node["cloudwatchlogs"]["state_file"]) }
-  end
+file File.join(node["cloudwatchlogs"]["home_dir"], "INSTALLED_BY_OPSWORKS") do
+  content "CloudWatch Logs agent was installed by OpsWorks. Do not delete this file."
 end
 
 service "awslogs" do

--- a/opsworks_cloudwatchlogs/recipes/uninstall.rb
+++ b/opsworks_cloudwatchlogs/recipes/uninstall.rb
@@ -2,22 +2,13 @@ service "awslogs" do
   action :stop
 end
 
-directory node["cloudwatchlogs"]["home_dir"] do
-  action :delete
-  recursive true
-end
-
-if platform?("amazon")
-  package "awslogs" do
-    action :remove
-  end
-else
-  directory "/opt/aws/cloudwatch" do
+[node["cloudwatchlogs"]["home_dir"], node["cloudwatchlogs"]["state_file_dir"]].each do |dir|
+  directory dir do
     action :delete
     recursive true
   end
+end
 
-  file "/etc/init.d/awslogs" do
-    action :delete
-  end
+file "/etc/init.d/awslogs" do
+  action :delete
 end

--- a/opsworks_cloudwatchlogs/templates/default/awscli.conf.erb
+++ b/opsworks_cloudwatchlogs/templates/default/awscli.conf.erb
@@ -1,4 +1,0 @@
-[plugins]
-cwlogs = cwlogs
-[default]
-region = <%= @region %>

--- a/opsworks_cloudwatchlogs/templates/default/awslogs.conf.erb
+++ b/opsworks_cloudwatchlogs/templates/default/awslogs.conf.erb
@@ -1,21 +1,10 @@
 [general]
-state_file = <%= @state_file %>
+state_file = <%= @state_file_dir %>/agent-state
 
-<% @cloudwatchlogs.each do |log_group_name, log_streams| %>
-<% log_streams.each do |log| %>
-<% if log["file"] == "AGENT"
-  log_path = node["cloudwatchlogs"]["AGENT_LOGS"]
-elsif log["file"] == "CHEF"
-  log_path = node["cloudwatchlogs"]["CHEF_LOGS"]
-else
-  log_path = log["file"]
-end %>
-[<%= log_group_name %> <%= log_path %>]
-datetime_format = [%Y-%m-%d %H:%M:%S]
-log_group_name = <%= log_group_name %>
-log_stream_name = <%= @hostname %> - <%= log_path %>
-initial_position = start_of_file
-file = <%= log_path %>
-
+<% @log_streams.each do |log_stream| %>
+[<%= log_stream[:log_group_name] %> <%= log_stream[:file] %>]
+<% log_stream.each do |key, value| %>
+<% next if value.nil? %>
+<%= key %> = <%= value %>
 <% end %>
 <% end %>

--- a/ruby/attributes/ruby.rb
+++ b/ruby/attributes/ruby.rb
@@ -21,7 +21,7 @@ case node["opsworks"]["ruby_version"]
 when "2.3"
   default[:ruby][:major_version] = "2"
   default[:ruby][:minor_version] = "3"
-  default[:ruby][:patch_version] = "3"
+  default[:ruby][:patch_version] = "4"
   default[:ruby][:pkgrelease]    = "1"
 
   default[:ruby][:full_version] = [node[:ruby][:major_version], node[:ruby][:minor_version]].join(".")
@@ -30,7 +30,7 @@ when "2.3"
 when "2.2"
   default[:ruby][:major_version] = '2'
   default[:ruby][:minor_version] = '2'
-  default[:ruby][:patch_version] = "6"
+  default[:ruby][:patch_version] = "7"
   default[:ruby][:pkgrelease]    = '1'
 
   default[:ruby][:full_version] = [node[:ruby][:major_version], node[:ruby][:minor_version]].join(".")

--- a/ruby/attributes/ruby.rb
+++ b/ruby/attributes/ruby.rb
@@ -21,7 +21,7 @@ case node["opsworks"]["ruby_version"]
 when "2.3"
   default[:ruby][:major_version] = "2"
   default[:ruby][:minor_version] = "3"
-  default[:ruby][:patch_version] = "4"
+  default[:ruby][:patch_version] = "5"
   default[:ruby][:pkgrelease]    = "1"
 
   default[:ruby][:full_version] = [node[:ruby][:major_version], node[:ruby][:minor_version]].join(".")


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2017/08/29/multiple-vulnerabilities-in-rubygems/ - 2.3.4 has security issues and have been fixed in higher versions.

Not sure how ruby upgrades are handled. I'm assuming a build has to be uploaded to the S3 bucket as well. Creating a PR nevertheless to initiate the process.

Thanks!