### PR TITLE
Bump Ruby to version 2.3.7 and 2.6.1

### DIFF
--- a/passenger_apache2/attributes/passenger.rb
+++ b/passenger_apache2/attributes/passenger.rb
@@ -33,6 +33,8 @@ when /^2\.2/
   default[:passenger][:gems_path] = '/usr/local/lib/ruby/gems/2.2.0/gems'
 when /^2\.3/
   default[:passenger][:gems_path] = '/usr/local/lib/ruby/gems/2.3.0/gems'
+when /^2\.6/
+  default[:passenger][:gems_path] = '/usr/local/lib/ruby/gems/2.6.0/gems'
 else
   Chef::Log.warn "Unsupported Ruby version '#{node[:opsworks][:ruby_version]}'. Unable to set passenger gems_path."
   default[:passenger][:gems_path] = '/'

--- a/ruby/attributes/ruby.rb
+++ b/ruby/attributes/ruby.rb
@@ -18,6 +18,15 @@ include_attribute 'opsworks_initial_setup::default'
 include_attribute 'opsworks_commons::default'
 
 case node["opsworks"]["ruby_version"]
+when "2.6"
+  default[:ruby][:major_version] = "2"
+  default[:ruby][:minor_version] = "6"
+  default[:ruby][:patch_version] = "1"
+  default[:ruby][:pkgrelease]    = "1"
+
+  default[:ruby][:full_version] = [node[:ruby][:major_version], node[:ruby][:minor_version]].join(".")
+  default[:ruby][:version] = [node[:ruby][:full_version], node[:ruby][:patch_version]].join(".")
+
 when "2.3"
   default[:ruby][:major_version] = "2"
   default[:ruby][:minor_version] = "3"

--- a/ruby/attributes/ruby.rb
+++ b/ruby/attributes/ruby.rb
@@ -21,7 +21,7 @@ case node["opsworks"]["ruby_version"]
 when "2.3"
   default[:ruby][:major_version] = "2"
   default[:ruby][:minor_version] = "3"
-  default[:ruby][:patch_version] = "4"
+  default[:ruby][:patch_version] = "7"
   default[:ruby][:pkgrelease]    = "1"
 
   default[:ruby][:full_version] = [node[:ruby][:major_version], node[:ruby][:minor_version]].join(".")


### PR DESCRIPTION
https://docs.aws.amazon.com/opsworks/latest/userguide/workingcookbook-ruby.html

OpsWorks Chef 11.10 officially supports Ruby 2.6.1 (since agent version `3451`) and 2.3.7 (since agent version `3448`)

* Bump 2.3.x default Ruby version to 2.3.7.
* Support Ruby 2.6.1
